### PR TITLE
Add ability to clone master skill

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+
+log/*
+tmp/*
+
+*.swp
+*.swo
+
+node_modules/*

--- a/app/admin/occupation_standards.rb
+++ b/app/admin/occupation_standards.rb
@@ -20,7 +20,11 @@ ActiveAdmin.register OccupationStandard do
     if request.post?
       args = params.require(resource.type.underscore.to_sym).permit(:creator_id, :organization_id).to_h.symbolize_keys
       os = resource.unregistered_clone(args)
-      redirect_to admin_occupation_standard_path(os)
+      if os.persisted?
+        redirect_to admin_occupation_standard_path(os)
+      else
+        render :clone_master_skill
+      end
     end
   end
 

--- a/app/admin/occupation_standards.rb
+++ b/app/admin/occupation_standards.rb
@@ -12,7 +12,20 @@ ActiveAdmin.register OccupationStandard do
   remove_filter :occupation_standard_skills
   remove_filter :occupation_standard_work_processes
 
+  action_item :clone_master_skill, only: :show do
+    link_to 'Clone Occupation Standard', clone_master_skill_admin_occupation_standard_path(occupation_standard)
+  end
+
+  member_action :clone_master_skill, method: [:get, :post] do
+    if request.post?
+      args = params.require(resource.type.underscore.to_sym).permit(:creator_id, :organization_id).to_h.symbolize_keys
+      os = resource.unregistered_clone(args)
+      redirect_to admin_occupation_standard_path(os)
+    end
+  end
+
   index do
+    selectable_column
     column :id
     column :type
     column :organization

--- a/app/admin/occupation_standards.rb
+++ b/app/admin/occupation_standards.rb
@@ -19,7 +19,7 @@ ActiveAdmin.register OccupationStandard do
   member_action :clone_master_skill, method: [:get, :post] do
     if request.post?
       args = params.require(resource.type.underscore.to_sym).permit(:creator_id, :organization_id).to_h.symbolize_keys
-      os = resource.unregistered_clone(args)
+      os = resource.clone_as_unregistered!(args)
       if os.persisted?
         redirect_to admin_occupation_standard_path(os)
       else

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -13,18 +13,25 @@ class OccupationStandard < ApplicationRecord
   validates :title, presence: true
 
   def unregistered_clone(creator_id:, organization_id:)
-    os = UnregisteredStandard.create(
-      creator_id: creator_id,
-      organization_id: organization_id,
-      occupation: occupation,
-      title: title,
-      parent_occupation_standard: self,
-    )
+    begin
+      OccupationStandard.transaction do
+        os = UnregisteredStandard.create!(
+          creator_id: creator_id,
+          organization_id: organization_id,
+          occupation: occupation,
+          title: title,
+          parent_occupation_standard: self,
+        )
 
-    os.occupation_standard_work_processes = occupation_standard_work_processes.map(&:dup)
-    os.occupation_standard_skills = occupation_standard_skills.map(&:dup)
+        os.occupation_standard_work_processes = occupation_standard_work_processes.map(&:dup)
+        os.occupation_standard_skills = occupation_standard_skills.map(&:dup)
 
-    os
+        os
+      end
+    rescue Exception => e
+      errors.add(:base, e.message)
+      OccupationStandard.new
+    end
   end
 
   def to_s

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -12,6 +12,21 @@ class OccupationStandard < ApplicationRecord
 
   validates :title, presence: true
 
+  def unregistered_clone(user:, organization:)
+    os = UnregisteredStandard.create(
+      creator: user,
+      organization: organization,
+      occupation: occupation,
+      title: title,
+      parent_occupation_standard: self,
+    )
+
+    os.occupation_standard_work_processes = occupation_standard_work_processes.map(&:dup)
+    os.occupation_standard_skills = occupation_standard_skills.map(&:dup)
+
+    os
+  end
+
   def to_s
     "#{title} (#{organization.title})"
   end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -12,7 +12,7 @@ class OccupationStandard < ApplicationRecord
 
   validates :title, presence: true
 
-  def unregistered_clone(creator_id:, organization_id:)
+  def clone_as_unregistered!(creator_id:, organization_id:)
     begin
       OccupationStandard.transaction do
         os = UnregisteredStandard.create!(

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -12,10 +12,10 @@ class OccupationStandard < ApplicationRecord
 
   validates :title, presence: true
 
-  def unregistered_clone(user:, organization:)
+  def unregistered_clone(user_id:, organization_id:)
     os = UnregisteredStandard.create(
-      creator: user,
-      organization: organization,
+      creator_id: user_id,
+      organization_id: organization_id,
       occupation: occupation,
       title: title,
       parent_occupation_standard: self,

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -19,7 +19,7 @@ class OccupationStandard < ApplicationRecord
           creator_id: creator_id,
           organization_id: organization_id,
           occupation: occupation,
-          title: title,
+          title: "#{title} COPY",
           parent_occupation_standard: self,
         )
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -12,9 +12,9 @@ class OccupationStandard < ApplicationRecord
 
   validates :title, presence: true
 
-  def unregistered_clone(user_id:, organization_id:)
+  def unregistered_clone(creator_id:, organization_id:)
     os = UnregisteredStandard.create(
-      creator_id: user_id,
+      creator_id: creator_id,
       organization_id: organization_id,
       occupation: occupation,
       title: title,

--- a/app/views/admin/occupation_standards/clone_master_skill.html.erb
+++ b/app/views/admin/occupation_standards/clone_master_skill.html.erb
@@ -1,0 +1,10 @@
+<%= semantic_form_for [:admin, resource], url: clone_master_skill_admin_occupation_standard_path(resource), method: :post do |f| %>
+  <%= f.semantic_errors(*f.object.errors.keys) %>
+    <%= f.inputs do %>
+      <%= f.input :organization %>
+      <%= f.input :creator %>
+    <% end %>
+    <%= f.actions do %>
+      <%= f.action :submit, label: "Clone Occupation Standard" %>
+    <% end %>
+<% end %>

--- a/spec/factories/occupation_standards.rb
+++ b/spec/factories/occupation_standards.rb
@@ -6,7 +6,5 @@ FactoryBot.define do
     association :creator, factory: :user
     occupation
     data_trust_approval { false }
-    completed_at { Time.current }
-    published_at { Time.current }
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :organization do
     type { "" }
-    title { "MyString" }
-    logo_url { "MyString" }
+    sequence(:title) { |n| "Org Title #{n}" }
+    logo_url { "http://www.example.com" }
     registers_standards { false }
   end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OccupationStandard, type: :model do
       expect(os).to be_a(UnregisteredStandard)
       expect(os.skills).to match_array occupation_standard.skills
       expect(os.work_processes).to match_array occupation_standard.work_processes
-      expect(os.title).to eq "OS Title"
+      expect(os.title).to eq "OS Title COPY"
       expect(os.occupation).to eq os.occupation
       expect(os.parent_occupation_standard).to eq occupation_standard
       expect(os.creator).to eq user

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OccupationStandard, type: :model do
     let(:organization) { create(:organization) }
 
     it "creates UnregisteredStandard" do
-      os = occupation_standard.unregistered_clone(user_id: user.id, organization_id: organization.id)
+      os = occupation_standard.unregistered_clone(creator_id: user.id, organization_id: organization.id)
       expect(os).to be_a(UnregisteredStandard)
       expect(os.skills).to match_array occupation_standard.skills
       expect(os.work_processes).to match_array occupation_standard.work_processes

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -13,18 +13,31 @@ RSpec.describe OccupationStandard, type: :model do
     let(:user) { create(:user) }
     let(:organization) { create(:organization) }
 
-    it "creates UnregisteredStandard" do
-      os = occupation_standard.clone_as_unregistered!(creator_id: user.id, organization_id: organization.id)
-      expect(os).to be_a(UnregisteredStandard)
-      expect(os.skills).to match_array occupation_standard.skills
-      expect(os.work_processes).to match_array occupation_standard.work_processes
-      expect(os.title).to eq "OS Title COPY"
-      expect(os.occupation).to eq os.occupation
-      expect(os.parent_occupation_standard).to eq occupation_standard
-      expect(os.creator).to eq user
-      expect(os.organization).to eq organization
-      expect(os.completed_at).to be nil
-      expect(os.published_at).to be nil
+    context "when successful" do
+      it "creates UnregisteredStandard" do
+        os = occupation_standard.clone_as_unregistered!(creator_id: user.id, organization_id: organization.id)
+        expect(os).to be_a(UnregisteredStandard)
+        expect(os.skills).to match_array occupation_standard.skills
+        expect(os.work_processes).to match_array occupation_standard.work_processes
+        expect(os.title).to eq "OS Title COPY"
+        expect(os.occupation).to eq os.occupation
+        expect(os.parent_occupation_standard).to eq occupation_standard
+        expect(os.creator).to eq user
+        expect(os.organization).to eq organization
+        expect(os.completed_at).to be nil
+        expect(os.published_at).to be nil
+      end
+    end
+
+    context "when unsuccessful" do
+      let(:error) { StandardError.new("error msg") }
+
+      it "does not create new standard" do
+        allow(UnregisteredStandard).to receive(:create!).and_raise(error)
+        os = occupation_standard.clone_as_unregistered!(creator_id: user.id, organization_id: organization.id)
+        expect(os).to be_new_record
+        expect(occupation_standard.errors.full_messages.to_sentence).to eq "error msg"
+      end
     end
   end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OccupationStandard, type: :model do
     expect(os.valid?).to be true
   end
 
-  describe "#unregistered_clone" do
+  describe "#clone_as_unregistered!" do
     let!(:occupation_standard) { create(:occupation_standard, title: "OS Title", completed_at: Time.current, published_at: Time.current) }
     let!(:oswp) { create_list(:occupation_standard_work_process, 2, occupation_standard: occupation_standard) }
     let!(:oss) { create_list(:occupation_standard_skill, 2, occupation_standard: occupation_standard) }
@@ -14,7 +14,7 @@ RSpec.describe OccupationStandard, type: :model do
     let(:organization) { create(:organization) }
 
     it "creates UnregisteredStandard" do
-      os = occupation_standard.unregistered_clone(creator_id: user.id, organization_id: organization.id)
+      os = occupation_standard.clone_as_unregistered!(creator_id: user.id, organization_id: organization.id)
       expect(os).to be_a(UnregisteredStandard)
       expect(os.skills).to match_array occupation_standard.skills
       expect(os.work_processes).to match_array occupation_standard.work_processes

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe OccupationStandard, type: :model do
     let(:organization) { create(:organization) }
 
     it "creates UnregisteredStandard" do
-      os = occupation_standard.unregistered_clone(user: user, organization: organization)
+      os = occupation_standard.unregistered_clone(user_id: user.id, organization_id: organization.id)
       expect(os).to be_a(UnregisteredStandard)
       expect(os.skills).to match_array occupation_standard.skills
       expect(os.work_processes).to match_array occupation_standard.work_processes

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -5,4 +5,26 @@ RSpec.describe OccupationStandard, type: :model do
     os = build(:occupation_standard)
     expect(os.valid?).to be true
   end
+
+  describe "#unregistered_clone" do
+    let!(:occupation_standard) { create(:occupation_standard, title: "OS Title", completed_at: Time.current, published_at: Time.current) }
+    let!(:oswp) { create_list(:occupation_standard_work_process, 2, occupation_standard: occupation_standard) }
+    let!(:oss) { create_list(:occupation_standard_skill, 2, occupation_standard: occupation_standard) }
+    let(:user) { create(:user) }
+    let(:organization) { create(:organization) }
+
+    it "creates UnregisteredStandard" do
+      os = occupation_standard.unregistered_clone(user: user, organization: organization)
+      expect(os).to be_a(UnregisteredStandard)
+      expect(os.skills).to match_array occupation_standard.skills
+      expect(os.work_processes).to match_array occupation_standard.work_processes
+      expect(os.title).to eq "OS Title"
+      expect(os.occupation).to eq os.occupation
+      expect(os.parent_occupation_standard).to eq occupation_standard
+      expect(os.creator).to eq user
+      expect(os.organization).to eq organization
+      expect(os.completed_at).to be nil
+      expect(os.published_at).to be nil
+    end
+  end
 end


### PR DESCRIPTION
closes #38 

## Description
- Added button on Occupation Standard admin page that creates an UnregisteredStandard clone.
- Added dockerignore file that excludes `node_modules` folder which may be the cause of the integrity error when trying to start web container.

## QA

- [ ] Log in as admin: admin@example.com/password
- [ ] Create or upload occupation standards ([test file](https://github.com/WorkHands/RAPiDSkills/blob/master/spec/fixtures/files/dog_walking.csv))
- [ ] View Occupation Standard. Click "Clone Occupation Standard" button.
- [ ] Select creator, organization, click Clone button. Verify creates new UnregisteredStandard correctly.

Question: Can any type of OccupationStandard be cloned?