### PR TITLE
Updates readme so you can copy/paste for copying example config files…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The following commands should just be run for the initial setup only. Rebuilding
 1. Install [Docker Community Edition](https://docs.docker.com/install/) if it
    is not already installed.
 1. Clone the repository.
-2. Copy `config/database.yml.example` to `config/database.yml`.
-2. Copy `config/docker.env.example` to `config/docker.env`. It is not necessary to change any of the values.
+2. Copy `config/database.yml.example` to `config/database.yml`: `cp config/database.yml.example config/database.yml`.
+2. Copy `config/docker.env.example` to `config/docker.env`:  `cp config/docker.env.example config/docker.env`. It is not necessary to change any of the values.
 3. Run `docker-compose build` to build images for all services.
 4. Run `docker-compose up -d database` to start the database service.
 4. Run `docker-compose run --rm web rails db:reset` to create the dev and test databases, load the schema, and run the seeds file.


### PR DESCRIPTION
I just had to do this again (i think the `.gitignore` was updated?) and realized it'd be easier if i could just copy/paste the whole command for the example config files.