### PR TITLE
Set yarn integrity check to false for development

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
closes #60 

I'm actually too afraid to disentangle webpacker from the app, so just flipping the yarn integrity check to false since we shouldn't be using it anyway.