### PR TITLE
Fix skill -> work_process association

### DIFF
--- a/app/admin/occupation_standards.rb
+++ b/app/admin/occupation_standards.rb
@@ -68,16 +68,6 @@ ActiveAdmin.register OccupationStandard do
       row :data_trust_approval
       row :parent_occupation_standard
       row :industry
-      table_for os.occupation_standard_work_processes.includes(:work_process) do
-        column "Work Processes" do |oswp|
-          link_to oswp.work_process.to_s, admin_occupation_standard_work_process_path(oswp)
-        end
-      end
-      table_for os.occupation_standard_skills.includes(:skill) do
-        column "Skills" do |oss|
-          link_to oss.skill.to_s, admin_occupation_standard_skill_path(oss)
-        end
-      end
       row :completed_at
       row :published_at
       row :pdf do |occupation_standard|
@@ -89,6 +79,20 @@ ActiveAdmin.register OccupationStandard do
       row :source_file_url
       row :created_at
       row :updated_at
+
+      panel "Work Processes" do
+        os.occupation_standard_work_processes.includes(:work_process, :occupation_standard_skills, :skills).each do |oswp|
+          panel link_to oswp.work_process.to_s, admin_occupation_standard_work_process_path(oswp) do
+
+            table_for oswp.skills do
+              column "Skills" do |skill|
+                oss = os.occupation_standard_skills.where(skill: skill).first
+                link_to skill.to_s, admin_occupation_standard_skill_path(oss)
+              end
+            end
+          end
+        end
+      end
     end
     active_admin_comments
   end

--- a/app/admin/occupation_standards.rb
+++ b/app/admin/occupation_standards.rb
@@ -81,14 +81,30 @@ ActiveAdmin.register OccupationStandard do
       row :updated_at
 
       panel "Work Processes" do
+        columns do
+          column do
+            span "Title", class: "header"
+          end
+          column do
+            span "Hours", class: "header"
+          end
+          column do
+            span "Skills", class: "header"
+          end
+        end
         os.occupation_standard_work_processes.includes(:work_process, :occupation_standard_skills, :skills).each do |oswp|
-          panel link_to oswp.work_process.to_s, admin_occupation_standard_work_process_path(oswp) do
-
-            table_for oswp.skills do
-              column "Skills" do |skill|
+          columns do
+            column do
+              link_to oswp.work_process.to_s, admin_occupation_standard_work_process_path(oswp)
+            end
+            column do
+              oswp.hours
+            end
+            column do
+              oswp.skills.map do |skill|
                 oss = os.occupation_standard_skills.where(skill: skill).first
                 link_to skill.to_s, admin_occupation_standard_skill_path(oss)
-              end
+              end.join(", ").html_safe
             end
           end
         end

--- a/app/assets/stylesheets/active_admin_customizations.scss.css
+++ b/app/assets/stylesheets/active_admin_customizations.scss.css
@@ -3,3 +3,7 @@ p.info {
   font-size: 1.5em;
   margin-bottom: 9px;
 }
+
+.header {
+  font-weight: bold;
+}

--- a/app/jobs/generate_occupation_standard_pdf_job.rb
+++ b/app/jobs/generate_occupation_standard_pdf_job.rb
@@ -4,6 +4,6 @@ class GenerateOccupationStandardPdfJob < ApplicationJob
   def perform(occupation_standard_id)
     os = OccupationStandard.find(occupation_standard_id)
     pdf = ::OccupationStandardPdf.new(os)
-    os.pdf.attach(io: StringIO.new(pdf.render), filename: "#{os.title.parameterize(separator: '_')}_#{os.id}.pdf")
+    os.pdf.attach(io: StringIO.new(pdf.render), filename: "#{os.title.parameterize(separator: '_')}_#{I18n.l(Time.current, format: :filename)}.pdf")
   end
 end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -41,18 +41,18 @@ class DataImport < ApplicationRecord
               title: row["work_process_title"],
               description: row["work_process_description"],
             ).first_or_create!
-            OccupationStandardWorkProcess.where(
+            oswp = OccupationStandardWorkProcess.where(
               occupation_standard: occupation_standard,
               work_process: work_process,
               hours: row["work_process_hours"],
             ).first_or_create!(sort_order: row["work_process_sort"])
             skill = Skill.where(
               description: row["skill"],
-              work_process: work_process,
             ).first_or_create!
             OccupationStandardSkill.where(
               occupation_standard: occupation_standard,
               skill: skill,
+              occupation_standard_work_process: oswp,
             ).first_or_create!(sort_order: row["skill_sort"])
           end
         end

--- a/app/models/occupation_standard_skill.rb
+++ b/app/models/occupation_standard_skill.rb
@@ -1,6 +1,7 @@
 class OccupationStandardSkill < ApplicationRecord
   belongs_to :occupation_standard
   belongs_to :skill
+  belongs_to :occupation_standard_work_process
 
   validates :occupation_standard, uniqueness: { scope: :skill }
 

--- a/app/models/occupation_standard_work_process.rb
+++ b/app/models/occupation_standard_work_process.rb
@@ -1,6 +1,8 @@
 class OccupationStandardWorkProcess < ApplicationRecord
   belongs_to :occupation_standard
   belongs_to :work_process
+  has_many :occupation_standard_skills
+  has_many :skills, through: :occupation_standard_skills
 
   validates :occupation_standard, uniqueness: { scope: :work_process }
   validates :hours, presence: true

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,5 +1,4 @@
 class Skill < ApplicationRecord
-  belongs_to :work_process, optional: true
   belongs_to :parent_skill, class_name: 'Skill', optional: true
   has_many :occupation_standard_skills
   has_many :occupation_standards, through: :occupation_standard_skills

--- a/app/pdfs/occupation_standard_pdf.rb
+++ b/app/pdfs/occupation_standard_pdf.rb
@@ -28,18 +28,21 @@ class OccupationStandardPdf < Prawn::Document
 
       text "Work Processes", size: 16, style: :bold
       move_down 3
-      os.occupation_standard_work_processes.each.with_index(1) do |oswp, index|
-        text "#{index}."
+      os.occupation_standard_work_processes.each do |oswp|
 
-        bounding_box([bounds.left + 18, cursor + 14], width: bounds.width) do
-          text oswp.work_process.title
+        bounding_box([bounds.left + 18, cursor], width: bounds.width) do
+          font_size(14) do
+            text oswp.work_process.title
+          end
           text "Hours: #{oswp.hours}"
 
-          bounding_box([bounds.left, cursor - 12], width: bounds.width - 20) do
-            text "Skills", size: 12, style: :bold
-            oswp.skills.each do |skill|
-              text skill.description
-              move_down 2
+          if oswp.skills.any?
+            bounding_box([bounds.left + 18, cursor - 12], width: bounds.width - 20) do
+              text "Skills", size: 12, style: :bold
+              oswp.skills.each do |skill|
+                text skill.description
+                move_down 2
+              end
             end
           end
         end

--- a/app/pdfs/occupation_standard_pdf.rb
+++ b/app/pdfs/occupation_standard_pdf.rb
@@ -12,7 +12,7 @@ class OccupationStandardPdf < Prawn::Document
       # footer
       bounding_box [bounds.left, bounds.bottom + 50], width: bounds.width do
         stroke_horizontal_rule
-        move_down(5)
+        move_down 5
         font_size(8) do
           text "Created for #{os.creator_name}"
           text "Last updated #{I18n.l(os.updated_at, format: :mdY)}"
@@ -27,17 +27,23 @@ class OccupationStandardPdf < Prawn::Document
       move_down 20
 
       text "Work Processes", size: 16, style: :bold
-      os.occupation_standard_work_processes.each do |oswp|
-        text oswp.work_process.title
-        text "Hours: #{oswp.hours}"
-        move_down 5
-      end
+      move_down 3
+      os.occupation_standard_work_processes.each.with_index(1) do |oswp, index|
+        text "#{index}."
 
-      move_down 20
-      text "Skills", size: 16, style: :bold
-      os.occupation_standard_skills.each do |oss|
-        text oss.skill.description
-        move_down 5
+        bounding_box([bounds.left + 18, cursor + 14], width: bounds.width) do
+          text oswp.work_process.title
+          text "Hours: #{oswp.hours}"
+
+          bounding_box([bounds.left, cursor - 12], width: bounds.width - 20) do
+            text "Skills", size: 12, style: :bold
+            oswp.skills.each do |skill|
+              text skill.description
+              move_down 2
+            end
+          end
+        end
+        move_down 15
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,4 @@ en:
     formats:
       mdY: "%m/%d/%Y"
       long: "%Y-%m-%d %H:%M:%S %Z"
+      filename: '%Y_%m_%d_%H_%M_%S'

--- a/db/migrate/20191018000121_add_occupation_standard_work_proccess_id_to_occupation_standard_skills.rb
+++ b/db/migrate/20191018000121_add_occupation_standard_work_proccess_id_to_occupation_standard_skills.rb
@@ -1,0 +1,5 @@
+class AddOccupationStandardWorkProccessIdToOccupationStandardSkills < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :occupation_standard_skills, :occupation_standard_work_process, null: false, foreign_key: true, index: { name: 'occupation_standard_work_process_id_idx' }
+  end
+end

--- a/db/migrate/20191018000928_remove_work_process_id_from_skills.rb
+++ b/db/migrate/20191018000928_remove_work_process_id_from_skills.rb
@@ -1,0 +1,5 @@
+class RemoveWorkProcessIdFromSkills < ActiveRecord::Migration[6.0]
+  def change
+    remove_reference :skills, :work_process, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_18_000121) do
+ActiveRecord::Schema.define(version: 2019_10_18_000928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,12 +149,10 @@ ActiveRecord::Schema.define(version: 2019_10_18_000121) do
   create_table "skills", force: :cascade do |t|
     t.text "description"
     t.integer "usage_count"
-    t.bigint "work_process_id"
     t.bigint "parent_skill_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["parent_skill_id"], name: "index_skills_on_parent_skill_id"
-    t.index ["work_process_id"], name: "index_skills_on_work_process_id"
   end
 
   create_table "standards_registrations", force: :cascade do |t|
@@ -225,7 +223,6 @@ ActiveRecord::Schema.define(version: 2019_10_18_000121) do
   add_foreign_key "occupation_standards", "organizations"
   add_foreign_key "occupation_standards", "users", column: "creator_id"
   add_foreign_key "skills", "skills", column: "parent_skill_id"
-  add_foreign_key "skills", "work_processes"
   add_foreign_key "standards_registrations", "occupation_standards"
   add_foreign_key "standards_registrations", "organizations"
   add_foreign_key "standards_registrations", "states"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_213838) do
+ActiveRecord::Schema.define(version: 2019_10_18_000121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,9 @@ ActiveRecord::Schema.define(version: 2019_10_16_213838) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "sort_order", default: 0
+    t.bigint "occupation_standard_work_process_id", null: false
     t.index ["occupation_standard_id"], name: "index_occupation_standard_skills_on_occupation_standard_id"
+    t.index ["occupation_standard_work_process_id"], name: "occupation_standard_work_process_id_idx"
     t.index ["skill_id"], name: "index_occupation_standard_skills_on_skill_id"
   end
 
@@ -212,6 +214,7 @@ ActiveRecord::Schema.define(version: 2019_10_16_213838) do
   add_foreign_key "data_imports", "users"
   add_foreign_key "locations", "organizations"
   add_foreign_key "locations", "states"
+  add_foreign_key "occupation_standard_skills", "occupation_standard_work_processes"
   add_foreign_key "occupation_standard_skills", "occupation_standards"
   add_foreign_key "occupation_standard_skills", "skills"
   add_foreign_key "occupation_standard_work_processes", "occupation_standards"

--- a/spec/factories/occupation_standard_skills.rb
+++ b/spec/factories/occupation_standard_skills.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :occupation_standard_skill do
     occupation_standard
     skill
+    occupation_standard_work_process
   end
 end

--- a/spec/factories/occupations.rb
+++ b/spec/factories/occupations.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :occupation, class: 'HybridOccupation' do
     type { "HybridOccupation" }
     sequence(:rapids_code) {|n| "code#{n}" }
-    onet_code { Faker::Lorem.characters(6) }
+    onet_code { Faker::Lorem.characters(number: 6) }
     onet_page_url { "http://www.example.com" }
     term_length_min { 1 }
     term_length_max { 1 }

--- a/spec/requests/admin/data_imports_spec.rb
+++ b/spec/requests/admin/data_imports_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe "Admin::DataImports", type: :request do
           expect(os1.skills[1].description).to eq "Communicate with human"
           expect(os1.skills[2].description).to eq "Demonstrate ability to walk by aggressive dogs"
           expect(os1.skills[3].description).to eq "Demonstrate ability to cross intersection"
+          expect(os1.occupation_standard_skills[0].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[0]
+          expect(os1.occupation_standard_skills[1].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[0]
+          expect(os1.occupation_standard_skills[2].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[1]
+          expect(os1.occupation_standard_skills[3].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[1]
 
           os2 = OccupationStandard.last
           expect(os2.title).to eq "Dog Training"
@@ -69,6 +73,7 @@ RSpec.describe "Admin::DataImports", type: :request do
           expect(os2.occupation_standard_work_processes[0].hours).to eq 50
 
           expect(os2.skills[0].description).to eq "Understand costs"
+          expect(os2.occupation_standard_skills[0].occupation_standard_work_process).to eq os2.occupation_standard_work_processes[0]
         end
       end
 
@@ -129,8 +134,8 @@ RSpec.describe "Admin::DataImports", type: :request do
         let(:organization) { create(:organization, title: "Acme Dog Walking") }
         let!(:os1) { create(:occupation_standard, occupation: occupation, organization: organization, title: "Heeling") }
         let!(:wp1) { create(:work_process, title: "Dealing with other dogs", description: "Handle interactions with other dogs") }
-        let!(:skill1) { create(:skill, description: "Demonstrate ability to cross intersection", work_process: wp1) }
-        let!(:oswp) { create(:occupation_standard_work_process, work_process: wp1, occupation_standard: os1, hours: 100) }
+        let!(:skill1) { create(:skill, description: "Demonstrate ability to cross intersection") }
+        let!(:oswp) { create(:occupation_standard_work_process, work_process: wp1, occupation_standard: os1, hours: 100, sort_order: 0) }
 
         it "saves data correctly" do
           expect{
@@ -160,7 +165,10 @@ RSpec.describe "Admin::DataImports", type: :request do
           expect(os1.skills[0].description).to eq "Communicate with dog"
           expect(os1.skills[1].description).to eq "Communicate with human"
           expect(os1.skills[2].description).to eq "Demonstrate ability to walk by aggressive dogs"
-          expect(os1.skills[3].description).to eq "Demonstrate ability to cross intersection"
+          expect(os1.occupation_standard_skills[0].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[1]
+          expect(os1.occupation_standard_skills[1].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[1]
+          expect(os1.occupation_standard_skills[2].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[0]
+          expect(os1.occupation_standard_skills[3].occupation_standard_work_process).to eq os1.occupation_standard_work_processes[0]
 
           os2 = OccupationStandard.last
           expect(os2.title).to eq "Dog Training"
@@ -173,6 +181,7 @@ RSpec.describe "Admin::DataImports", type: :request do
           expect(os2.occupation_standard_work_processes[0].hours).to eq 50
 
           expect(os2.skills[0].description).to eq "Understand costs"
+          expect(os2.occupation_standard_skills[0].occupation_standard_work_process).to eq os2.occupation_standard_work_processes[0]
         end
       end
 


### PR DESCRIPTION
closes #63 

## Updates

- Remove skill `belongs_to` work_process association.
- Add `belongs_to` association on occupation_standard_skill to occupation_standard_work_process
- Update pdf to nest work_process -> skills
- Update occupation_standard admin dashboard to nest work_process -> skills
- Update pdf filename to use a timestamp for now so you can tell when it's been updated

## QA

- [x] On Data Import admin page, import [test file](https://github.com/WorkHands/RAPiDSkills/blob/master/spec/fixtures/files/dog_walking.csv).
- [x] View newly created occupation standard. Should see table with work processes that list skills.
- [x] Click Generate PDF button.
- [x] PDF file should display skills nested under work processes
