### PR TITLE
Occupation, occupation standards endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.6.3'
 
 # Architecture
 gem 'rails', '~> 6.0.0'
+gem 'fast_jsonapi'
 gem 'pg'
 gem 'puma', '~> 3.11'
 gem 'webpacker', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       railties (>= 4.2.0)
     faker (2.3.0)
       i18n (~> 1.6.0)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -331,6 +333,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  fast_jsonapi
   pg
   prawn
   pry-nav

--- a/app.json
+++ b/app.json
@@ -16,9 +16,6 @@
     "MAILGUN_API_KEY": {
       "required": true
     },
-    "MAILGUN_DOMAIN": {
-      "required": true
-    },
     "MAILGUN_PUBLIC_KEY": {
       "required": true
     },

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -1,0 +1,15 @@
+class API::V1::OccupationStandardsController < ApplicationController
+  def index
+    @oss = OccupationStandard
+             .includes(:organization, :occupation, :industry)
+             .filter_collection(filter_params.to_h)
+             .order(id: :desc)
+    render json: API::V1::OccupationStandardSerializer.new(@oss)
+  end
+
+  private
+
+  def filter_params
+    params.permit(:occupation_id)
+  end
+end

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -2,14 +2,14 @@ class API::V1::OccupationStandardsController < ApplicationController
   def index
     @oss = OccupationStandard
              .includes(:organization, :occupation, :industry)
-             .filter_collection(filter_params.to_h)
+             .search(search_params.to_h)
              .order(id: :desc)
     render json: API::V1::OccupationStandardSerializer.new(@oss)
   end
 
   private
 
-  def filter_params
+  def search_params
     params.permit(:occupation_id)
   end
 end

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,4 +1,6 @@
 class API::V1::OccupationsController < ApplicationController
   def index
+    @occupations = Occupation.search(params[:q]).order(id: :desc)
+    render json: API::V1::OccupationSerializer.new(@occupations)
   end
 end

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,6 +1,6 @@
 class API::V1::OccupationsController < ApplicationController
   def index
-    @occupations = Occupation.search(params[:q]).order(id: :desc)
+    @occupations = Occupation.search(q: params[:q]).order(id: :desc)
     render json: API::V1::OccupationSerializer.new(@occupations)
   end
 end

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,6 +1,12 @@
 class API::V1::OccupationsController < ApplicationController
   def index
-    @occupations = Occupation.search(q: params[:q]).order(id: :desc)
+    @occupations = Occupation.search(search_params.to_h).order(id: :desc)
     render json: API::V1::OccupationSerializer.new(@occupations)
+  end
+
+  private
+
+  def search_params
+    params.permit(:q)
   end
 end

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,0 +1,4 @@
+class API::V1::OccupationsController < ApplicationController
+  def index
+  end
+end

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -5,7 +5,8 @@ class Occupation < ApplicationRecord
   has_many :industries, through: :occupation_standards
 
   class << self
-    def search(q)
+    def search(args={})
+      q = args[:q]
       return all if q.blank?
 
       terms = q.split(/\s+/)

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -4,6 +4,21 @@ class Occupation < ApplicationRecord
   has_many :occupation_standards
   has_many :industries, through: :occupation_standards
 
+  class << self
+    def search(q)
+      return all if q.blank?
+
+      Occupation
+        .select("O.*")
+        .from("occupations O
+                 LEFT JOIN (SELECT
+                              occupations.id,
+                              UNNEST(title_aliases) AS str
+                            FROM occupations) AS sub ON (O.id = sub.id)")
+        .where("O.title ILIKE :q OR sub.str ILIKE :q", q: "%#{q}%")
+    end
+  end
+
   def title_aliases=(list)
     if list.is_a?(String)
       super list.split(/;\s+/)

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -9,13 +9,14 @@ class Occupation < ApplicationRecord
       return all if q.blank?
 
       Occupation
-        .select("O.*")
-        .from("occupations O
-                 LEFT JOIN (SELECT
-                              occupations.id,
-                              UNNEST(title_aliases) AS str
-                            FROM occupations) AS sub ON (O.id = sub.id)")
-        .where("O.title ILIKE :q OR sub.str ILIKE :q", q: "%#{q}%")
+        .select("occupations.*")
+        .from("occupations
+                 LEFT JOIN
+               (SELECT
+                  occupations.id,
+                  UNNEST(title_aliases) AS str
+                FROM occupations) AS sub ON (occupations.id = sub.id)")
+        .where("occupations.title ILIKE :q OR sub.str ILIKE :q", q: "%#{q}%")
     end
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -16,7 +16,7 @@ class OccupationStandard < ApplicationRecord
 
   delegate :title, to: :organization, prefix: true
   delegate :title, to: :occupation, prefix: true
-  delegate :title, to: :industry, prefix: true
+  delegate :title, to: :industry, prefix: true, allow_nil: true
   delegate :name, to: :creator, prefix: true
 
   class << self

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -19,18 +19,11 @@ class OccupationStandard < ApplicationRecord
   delegate :title, to: :industry, prefix: true, allow_nil: true
   delegate :name, to: :creator, prefix: true
 
+  scope :occupation, ->(occupation_id) { where(occupation_id: occupation_id) if occupation_id.present? }
+
   class << self
-    def filter_collection(options={})
-      options.delete_if { |k, v| v != false && v.blank? }
-      options.delete_if { |k, v| v.kind_of?(Array) and v.reject(&:blank?).empty? }
-      options.inject(all) do |scope, (key, value)|
-        case key.to_s
-        when "occupation_id"
-          scope.where("#{key}": value)
-        else
-          scope
-        end
-      end
+    def search(args={})
+      occupation(args[:occupation_id])
     end
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -19,6 +19,21 @@ class OccupationStandard < ApplicationRecord
   delegate :title, to: :industry, prefix: true
   delegate :name, to: :creator, prefix: true
 
+  class << self
+    def filter_collection(options={})
+      options.delete_if { |k, v| v != false && v.blank? }
+      options.delete_if { |k, v| v.kind_of?(Array) and v.reject(&:blank?).empty? }
+      options.inject(all) do |scope, (key, value)|
+        case key.to_s
+        when "occupation_id"
+          scope.where("#{key}": value)
+        else
+          scope
+        end
+      end
+    end
+  end
+
   def clone_as_unregistered!(creator_id:, organization_id:)
     begin
       OccupationStandard.transaction do

--- a/app/serializers/api/v1/occupation_serializer.rb
+++ b/app/serializers/api/v1/occupation_serializer.rb
@@ -1,0 +1,13 @@
+class API::V1::OccupationSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id,
+             :title,
+             :rapids_code,
+             :onet_code,
+             :term_length_min,
+             :term_length_max
+
+  attribute :title_aliases do |object|
+    object.title_aliases.join(", ")
+  end
+end

--- a/app/serializers/api/v1/occupation_standard_serializer.rb
+++ b/app/serializers/api/v1/occupation_standard_serializer.rb
@@ -1,0 +1,7 @@
+class API::V1::OccupationStandardSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :title,
+             :organization_title,
+             :occupation_title,
+             :industry_title
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,10 @@ Rails.application.routes.draw do
   authenticate :user, lambda { |u| u.admin? } do
     mount Sidekiq::Web => '/admin/sidekiq'
   end
+
+  namespace :api, path: '', defaults: { format: :json } do
+    namespace :v1 do
+      resources :occupations, only: [:index]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace :api, path: '', defaults: { format: :json } do
     namespace :v1 do
       resources :occupations, only: [:index]
+      resources :occupation_standards, only: [:index]
     end
   end
 end

--- a/db/migrate/20191024212954_add_index_to_occupation_title.rb
+++ b/db/migrate/20191024212954_add_index_to_occupation_title.rb
@@ -1,0 +1,5 @@
+class AddIndexToOccupationTitle < ActiveRecord::Migration[6.0]
+  def change
+    add_index :occupations, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_18_000928) do
+ActiveRecord::Schema.define(version: 2019_10_24_212954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2019_10_18_000928) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["rapids_code"], name: "index_occupations_on_rapids_code", unique: true
+    t.index ["title"], name: "index_occupations_on_title"
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/spec/factories/occupation_standards.rb
+++ b/spec/factories/occupation_standards.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :occupation_standard do
+  factory :occupation_standard, class: 'FrameworkStandard'  do
     type { "FrameworkStandard" }
     title { Faker::Job.title }
     organization

--- a/spec/factories/occupations.rb
+++ b/spec/factories/occupations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :occupation, class: 'HybridOccupation' do
     type { "HybridOccupation" }
     sequence(:rapids_code) {|n| "code#{n}" }
+    title { Faker::Job.title }
     onet_code { Faker::Lorem.characters(number: 6) }
     onet_page_url { "http://www.example.com" }
     term_length_min { 1 }

--- a/spec/models/occupation_spec.rb
+++ b/spec/models/occupation_spec.rb
@@ -24,34 +24,34 @@ RSpec.describe Occupation, type: :model do
     let!(:occupation3) { create(:occupation, title: "Moo Bar", title_aliases: ["Mar", "Foo"]) }
 
     it "returns all results when q is blank" do
-      results = Occupation.search(nil)
+      results = Occupation.search(q: nil)
       expect(results).to contain_exactly occupation1, occupation2, occupation3
 
-      results = Occupation.search("")
+      results = Occupation.search(q: "")
       expect(results).to contain_exactly occupation1, occupation2, occupation3
     end
 
     it "returns matched results when q is not blank" do
-      results = Occupation.search("Foo")
+      results = Occupation.search(q: "Foo")
       expect(results).to contain_exactly occupation1, occupation3
 
-      results = Occupation.search("Mar")
+      results = Occupation.search(q: "Mar")
       expect(results).to contain_exactly occupation3
 
-      results = Occupation.search("Baz")
+      results = Occupation.search(q: "Baz")
       expect(results).to contain_exactly occupation2
     end
 
     it "returns OR matched results when q has multiple terms" do
-      results = Occupation.search("Baz Fob")
+      results = Occupation.search(q: "Baz Fob")
       expect(results).to contain_exactly occupation2
 
-      results = Occupation.search("Foo Mar")
+      results = Occupation.search(q: "Foo Mar")
       expect(results).to contain_exactly occupation1, occupation3
     end
 
     it "returns no results when q does not match" do
-      results = Occupation.search("Fob")
+      results = Occupation.search(q: "Fob")
       expect(results).to be_empty
     end
   end

--- a/spec/models/occupation_spec.rb
+++ b/spec/models/occupation_spec.rb
@@ -17,4 +17,34 @@ RSpec.describe Occupation, type: :model do
     os = create(:occupation_standard, industry: industry)
     expect(os.occupation.industries).to eq [industry]
   end
+
+  describe ".search" do
+    let!(:occupation1) { create(:occupation, title: "Foo Bar") }
+    let!(:occupation2) { create(:occupation, title: "Bar Baz") }
+    let!(:occupation3) { create(:occupation, title: "Moo Bar", title_aliases: ["Mar", "Foo"]) }
+
+    it "returns all results when q is blank" do
+      results = Occupation.search(nil)
+      expect(results).to contain_exactly occupation1, occupation2, occupation3
+
+      results = Occupation.search("")
+      expect(results).to contain_exactly occupation1, occupation2, occupation3
+    end
+
+    it "returns matched results when q is not blank" do
+      results = Occupation.search("Foo")
+      expect(results).to contain_exactly occupation1, occupation3
+
+      results = Occupation.search("Mar")
+      expect(results).to contain_exactly occupation3
+
+      results = Occupation.search("Baz")
+      expect(results).to contain_exactly occupation2
+    end
+
+    it "returns no results when q does not match" do
+      results = Occupation.search("Fob")
+      expect(results).to be_empty
+    end
+  end
 end

--- a/spec/models/occupation_spec.rb
+++ b/spec/models/occupation_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe Occupation, type: :model do
       expect(results).to contain_exactly occupation2
     end
 
+    it "returns OR matched results when q has multiple terms" do
+      results = Occupation.search("Baz Fob")
+      expect(results).to contain_exactly occupation2
+
+      results = Occupation.search("Foo Mar")
+      expect(results).to contain_exactly occupation1, occupation3
+    end
+
     it "returns no results when q does not match" do
       results = Occupation.search("Fob")
       expect(results).to be_empty

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe OccupationStandard, type: :model do
     expect(os.valid?).to be true
   end
 
+  describe ".filter_collection" do
+    let(:occupation) { create(:occupation) }
+    let!(:os1) { create(:occupation_standard, occupation: occupation) }
+    let!(:os2) { create(:occupation_standard, occupation: occupation) }
+    let!(:os3) { create(:occupation_standard) }
+
+    it "returns all objects if options are empty" do
+      expect(OccupationStandard.filter_collection).to contain_exactly os1, os2, os3
+    end
+
+    it "returns filtered objects for valid occupation_id" do
+      expect(OccupationStandard.filter_collection(occupation_id: occupation.id)).to contain_exactly os1, os2
+    end
+
+    it "returns no objects for invalid occupation_id" do
+      expect(OccupationStandard.filter_collection(occupation_id: 9999)).to be_empty
+    end
+  end
+
   describe "#clone_as_unregistered!" do
     let!(:occupation_standard) { create(:occupation_standard, title: "OS Title", completed_at: Time.current, published_at: Time.current) }
     let!(:oswp) { create_list(:occupation_standard_work_process, 2, occupation_standard: occupation_standard) }

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -6,22 +6,26 @@ RSpec.describe OccupationStandard, type: :model do
     expect(os.valid?).to be true
   end
 
-  describe ".filter_collection" do
+  describe ".search" do
     let(:occupation) { create(:occupation) }
     let!(:os1) { create(:occupation_standard, occupation: occupation) }
     let!(:os2) { create(:occupation_standard, occupation: occupation) }
     let!(:os3) { create(:occupation_standard) }
 
     it "returns all objects if options are empty" do
-      expect(OccupationStandard.filter_collection).to contain_exactly os1, os2, os3
+      expect(OccupationStandard.search).to contain_exactly os1, os2, os3
+    end
+
+    it "returns all objects if occupation_id is blank" do
+      expect(OccupationStandard.search(occupation_id: nil)).to contain_exactly os1, os2, os3
     end
 
     it "returns filtered objects for valid occupation_id" do
-      expect(OccupationStandard.filter_collection(occupation_id: occupation.id)).to contain_exactly os1, os2
+      expect(OccupationStandard.search(occupation_id: occupation.id)).to contain_exactly os1, os2
     end
 
     it "returns no objects for invalid occupation_id" do
-      expect(OccupationStandard.filter_collection(occupation_id: 9999)).to be_empty
+      expect(OccupationStandard.search(occupation_id: 9999)).to be_empty
     end
   end
 

--- a/spec/requests/api/v1/occupation_standards_spec.rb
+++ b/spec/requests/api/v1/occupation_standards_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::OccupationStandardsController, type: :request do
+  describe "GET #index" do
+    let(:occupation) { create(:occupation) }
+    let!(:os1) { create(:occupation_standard, occupation: occupation) }
+    let!(:os2) { create(:occupation_standard) }
+    let!(:os3) { create(:occupation_standard, occupation: occupation) }
+    let(:path) { "/v1/occupation_standards" }
+
+    it "returns the correct data" do
+      # With no occupation_id parameter, returns all data
+      get path
+      expect(response).to have_http_status(:success)
+      expect(json["data"].count).to eq 3
+      expect(json["data"][0]["id"]).to eq os3.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation_standard"
+      expect(json["data"][0]["attributes"]["title"]).to eq os3.title
+      expect(json["data"][0]["attributes"]["organization_title"]).to eq os3.organization.title
+      expect(json["data"][0]["attributes"]["occupation_title"]).to eq occupation.title
+      expect(json["data"][0]["attributes"]["industry_title"]).to be nil
+      expect(json["data"][1]["id"]).to eq os2.id.to_s
+      expect(json["data"][1]["type"]).to eq "occupation_standard"
+      expect(json["data"][1]["attributes"]["title"]).to eq os2.title
+      expect(json["data"][1]["attributes"]["organization_title"]).to eq os2.organization.title
+      expect(json["data"][1]["attributes"]["occupation_title"]).to eq os2.occupation.title
+      expect(json["data"][1]["attributes"]["industry_title"]).to be nil
+      expect(json["data"][2]["id"]).to eq os1.id.to_s
+      expect(json["data"][2]["type"]).to eq "occupation_standard"
+      expect(json["data"][2]["attributes"]["title"]).to eq os1.title
+      expect(json["data"][2]["attributes"]["organization_title"]).to eq os1.organization.title
+      expect(json["data"][2]["attributes"]["occupation_title"]).to eq occupation.title
+      expect(json["data"][2]["attributes"]["industry_title"]).to be nil
+
+      # With occupation_id parameter, returns matches
+      get path, params: { occupation_id: occupation.id }
+      expect(response).to have_http_status(:success)
+      expect(json["data"].count).to eq 2
+      expect(json["data"][0]["id"]).to eq os3.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation_standard"
+      expect(json["data"][0]["attributes"]["title"]).to eq os3.title
+      expect(json["data"][0]["attributes"]["organization_title"]).to eq os3.organization.title
+      expect(json["data"][0]["attributes"]["occupation_title"]).to eq occupation.title
+      expect(json["data"][0]["attributes"]["industry_title"]).to be nil
+      expect(json["data"][1]["id"]).to eq os1.id.to_s
+      expect(json["data"][1]["type"]).to eq "occupation_standard"
+      expect(json["data"][1]["attributes"]["title"]).to eq os1.title
+      expect(json["data"][1]["attributes"]["organization_title"]).to eq os1.organization.title
+      expect(json["data"][1]["attributes"]["occupation_title"]).to eq occupation.title
+      expect(json["data"][1]["attributes"]["industry_title"]).to be nil
+
+      # With bad occupation_id parameter, returns none
+      get path, params: { occupation_id: 9999 }
+      expect(response).to have_http_status(:success)
+      expect(json["data"]).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::OccupationsController, type: :request do
+  describe "GET #index" do
+    let!(:occupation1) { create(:occupation, title: "Foo Bar") }
+    let!(:occupation2) { create(:occupation, title: "Bar Baz") }
+    let!(:occupation3) { create(:occupation, title: "Moo Bar", title_aliases: ["Foo", "Mar"]) }
+    let(:path) { "/v1/occupations" }
+
+    it "returns the correct data" do
+      # With no search parameters, returns no data
+      get path
+      expect(response).to have_http_status(:success)
+      expect(json["payload"]).to be_empty
+
+      # With search query, returns matches
+      get path, params: { q: "Foo" }
+      expect(response).to have_http_status(:success)
+      expect(json["payload"].count).to eq 2
+      expect(json["payload"][0]["id"]).to eq occupation3.id
+      expect(json["payload"][0]["title"]).to eq "Moo Bar"
+      expect(json["payload"][0]["title_aliases"]).to eq "Foo, Mar"
+      expect(json["payload"][1]["id"]).to eq occupation1.id
+      expect(json["payload"][1]["title"]).to eq "Foo Bar"
+      expect(json["payload"][1]["title_aliases"]).to be_empty
+
+      get path, params: { q: "Foo Bar" }
+      expect(response).to have_http_status(:success)
+      expect(json["payload"].count).to eq 1
+      expect(json["payload"][0]["id"]).to eq occupation1.id
+      expect(json["payload"][0]["title"]).to eq "Foo Bar"
+      expect(json["payload"][0]["title_aliases"]).to be_empty
+
+      get path, params: { q: "Baz" }
+      expect(response).to have_http_status(:success)
+      expect(json["payload"].count).to eq 1
+      expect(json["payload"][0]["id"]).to eq occupation2.id
+      expect(json["payload"][0]["title"]).to eq "Bar Baz"
+      expect(json["payload"][0]["title_aliases"]).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -8,35 +8,56 @@ RSpec.describe API::V1::OccupationsController, type: :request do
     let(:path) { "/v1/occupations" }
 
     it "returns the correct data" do
-      # With no search parameters, returns no data
+      # With no search parameters, returns all data
       get path
       expect(response).to have_http_status(:success)
-      expect(json["payload"]).to be_empty
+      expect(json["data"].count).to eq 3
+      expect(json["data"][0]["id"]).to eq occupation3.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation"
+      expect(json["data"][0]["attributes"]["title"]).to eq "Moo Bar"
+      expect(json["data"][0]["attributes"]["title_aliases"]).to eq "Foo, Mar"
+      expect(json["data"][1]["id"]).to eq occupation2.id.to_s
+      expect(json["data"][1]["type"]).to eq "occupation"
+      expect(json["data"][1]["attributes"]["title"]).to eq "Bar Baz"
+      expect(json["data"][1]["attributes"]["title_aliases"]).to eq ""
+      expect(json["data"][2]["id"]).to eq occupation1.id.to_s
+      expect(json["data"][2]["type"]).to eq "occupation"
+      expect(json["data"][2]["attributes"]["title"]).to eq "Foo Bar"
+      expect(json["data"][2]["attributes"]["title_aliases"]).to eq ""
 
       # With search query, returns matches
       get path, params: { q: "Foo" }
       expect(response).to have_http_status(:success)
-      expect(json["payload"].count).to eq 2
-      expect(json["payload"][0]["id"]).to eq occupation3.id
-      expect(json["payload"][0]["title"]).to eq "Moo Bar"
-      expect(json["payload"][0]["title_aliases"]).to eq "Foo, Mar"
-      expect(json["payload"][1]["id"]).to eq occupation1.id
-      expect(json["payload"][1]["title"]).to eq "Foo Bar"
-      expect(json["payload"][1]["title_aliases"]).to be_empty
+      expect(json["data"].count).to eq 2
+      expect(json["data"][0]["id"]).to eq occupation3.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation"
+      expect(json["data"][0]["attributes"]["title"]).to eq "Moo Bar"
+      expect(json["data"][0]["attributes"]["title_aliases"]).to eq "Foo, Mar"
+      expect(json["data"][1]["id"]).to eq occupation1.id.to_s
+      expect(json["data"][1]["type"]).to eq "occupation"
+      expect(json["data"][1]["attributes"]["title"]).to eq "Foo Bar"
+      expect(json["data"][1]["attributes"]["title_aliases"]).to eq ""
 
       get path, params: { q: "Foo Bar" }
       expect(response).to have_http_status(:success)
-      expect(json["payload"].count).to eq 1
-      expect(json["payload"][0]["id"]).to eq occupation1.id
-      expect(json["payload"][0]["title"]).to eq "Foo Bar"
-      expect(json["payload"][0]["title_aliases"]).to be_empty
+      expect(json["data"].count).to eq 1
+      expect(json["data"][0]["id"]).to eq occupation1.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation"
+      expect(json["data"][0]["attributes"]["title"]).to eq "Foo Bar"
+      expect(json["data"][0]["attributes"]["title_aliases"]).to eq ""
 
       get path, params: { q: "Baz" }
       expect(response).to have_http_status(:success)
-      expect(json["payload"].count).to eq 1
-      expect(json["payload"][0]["id"]).to eq occupation2.id
-      expect(json["payload"][0]["title"]).to eq "Bar Baz"
-      expect(json["payload"][0]["title_aliases"]).to be_empty
+      expect(json["data"].count).to eq 1
+      expect(json["data"][0]["id"]).to eq occupation2.id.to_s
+      expect(json["data"][0]["type"]).to eq "occupation"
+      expect(json["data"][0]["attributes"]["title"]).to eq "Bar Baz"
+      expect(json["data"][0]["attributes"]["title_aliases"]).to eq ""
+
+      # With bad search parameters, returns no data
+      get path, params: { q: "Fob" }
+      expect(response).to have_http_status(:success)
+      expect(json["data"]).to be_empty
     end
   end
 end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe API::V1::OccupationsController, type: :request do
       expect(json["data"][1]["attributes"]["title"]).to eq "Foo Bar"
       expect(json["data"][1]["attributes"]["title_aliases"]).to eq ""
 
-      get path, params: { q: "Foo Bar" }
+      get path, params: { q: "Moo Mar" }
       expect(response).to have_http_status(:success)
       expect(json["data"].count).to eq 1
-      expect(json["data"][0]["id"]).to eq occupation1.id.to_s
+      expect(json["data"][0]["id"]).to eq occupation3.id.to_s
       expect(json["data"][0]["type"]).to eq "occupation"
-      expect(json["data"][0]["attributes"]["title"]).to eq "Foo Bar"
-      expect(json["data"][0]["attributes"]["title_aliases"]).to eq ""
+      expect(json["data"][0]["attributes"]["title"]).to eq "Moo Bar"
+      expect(json["data"][0]["attributes"]["title_aliases"]).to eq "Foo, Mar"
 
       get path, params: { q: "Baz" }
       expect(response).to have_http_status(:success)

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -15,6 +15,10 @@ module RequestSpecHelper
     logout(warden_scope(resource)) if resource
   end
 
+  def json
+    JSON.parse(response.body)
+  end
+
   private
 
   def warden_scope(resource)


### PR DESCRIPTION
closes #6 

## Description
- Added public occupations endpoint. Using OR search for multiple terms.
- Added public occupation standards endpoint (can search by occupation_id)

## QA

In Postman
- [x] http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupations should return all occupations
- [x] Try with some search queries:
    * http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupations?q=ship+welder
    * http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupations?q=ship+painter
- [x] http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupation_standards should return all occupation standards
- [x] http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupation_standards?occupation_id=1 should return a single response
- [x] http://rapid-skills-staging-pr-69.herokuapp.com/v1/occupation_standards?occupation_id=1357 should return 2 responses
## Notes
* Set this up using [JSON API specification](https://jsonapi.org/) for now.  Can change this later if we want.
* I think an AND search for multiple terms might be better than the OR search for occupations.