### PR TITLE
Add create user endpoint

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register User do
-  permit_params :email, :name, :role, :password, :password_confirmation
+  permit_params :email, :name, :role, :password, :password_confirmation, :employer_id
 
   action_item :change_password, only: [:edit, :show] do
     link_to 'Change Password', change_password_admin_user_path(user)
@@ -30,6 +30,7 @@ ActiveAdmin.register User do
   filter :role
   filter :name
   filter :email
+  filter :employer
   filter :current_sign_in_at
   filter :sign_in_count
   filter :created_at
@@ -39,6 +40,7 @@ ActiveAdmin.register User do
       f.input :name
       f.input :email
       f.input :role, include_blank: false
+      f.input :employer
       if f.object.new_record?
         f.input :password
         f.input :password_confirmation

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,3 +1,16 @@
 class API::V1::APIController < ApplicationController
   skip_before_action :verify_authenticity_token
+
+  private
+
+  def render_resource_error(resource)
+    render json: {
+      errors: [
+        {
+          status: "422",
+          detail: resource.errors.full_messages.to_sentence,
+        }
+      ]
+    }, status: :unprocessable_entity and return
+  end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,3 @@
+class API::V1::APIController < ApplicationController
+  skip_before_action :verify_authenticity_token
+end

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -1,4 +1,4 @@
-class API::V1::OccupationStandardsController < ApplicationController
+class API::V1::OccupationStandardsController < API::V1::APIController
   def index
     @oss = OccupationStandard
              .includes(:organization, :occupation, :industry)

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,4 +1,4 @@
-class API::V1::OccupationsController < ApplicationController
+class API::V1::OccupationsController < API::V1::APIController
   def index
     @occupations = Occupation.search(search_params.to_h).order(id: :desc)
     render json: API::V1::OccupationSerializer.new(@occupations)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,9 +3,11 @@ class API::V1::UsersController < API::V1::APIController
     @user = User.where(
       email: params[:data][:attributes][:email]
     ).first_or_initialize(password: SecureRandom.uuid) # tmp pw for now
-    @user.employer = Organization.where(title: params[:data][:attributes][:organization_title]).first_or_initialize
+    @user.employer = Organization.where(title: params[:data][:attributes][:organization_name]).first_or_initialize
     if @user.update(user_params)
-      render json: API::V1::UserSerializer.new(@user)
+      options = {}
+      options[:include] = [:employer] if @user.employer.persisted?
+      render json: API::V1::UserSerializer.new(@user, options)
     else
       render_resource_error(@user)
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,15 @@
+class API::V1::UsersController < ApplicationController
+  def create
+    @user = User.where(
+      email: params[:data][:attributes][:email]
+    ).first_or_initialize(password: SecureRandom.uuid) # tmp pw for now
+    @user.update(user_params) if @user.new_record?
+    render json: API::V1::UserSerializer.new(@user)
+  end
+
+  private
+
+  def user_params
+    params.require(:data).require(:attributes).permit(:email, :name)
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ class API::V1::UsersController < API::V1::APIController
     @user = User.where(
       email: params[:data][:attributes][:email]
     ).first_or_initialize(password: SecureRandom.uuid) # tmp pw for now
-    @user.employer = Organization.where(title: params[:data][:attributes][:organization_name]).first_or_initialize
+    @user.employer = Organization.where(title: params[:data][:attributes][:organization_title]).first_or_initialize
     if @user.update(user_params)
       render json: API::V1::UserSerializer.new(@user)
     else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,7 @@ class API::V1::UsersController < API::V1::APIController
     @user = User.where(
       email: params[:data][:attributes][:email]
     ).first_or_initialize(password: SecureRandom.uuid) # tmp pw for now
+    @user.employer = Organization.where(title: params[:data][:attributes][:organization_name]).first_or_initialize
     if @user.update(user_params)
       render json: API::V1::UserSerializer.new(@user)
     else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,15 +1,18 @@
-class API::V1::UsersController < ApplicationController
+class API::V1::UsersController < API::V1::APIController
   def create
     @user = User.where(
       email: params[:data][:attributes][:email]
     ).first_or_initialize(password: SecureRandom.uuid) # tmp pw for now
-    @user.update(user_params) if @user.new_record?
-    render json: API::V1::UserSerializer.new(@user)
+    if @user.update(user_params)
+      render json: API::V1::UserSerializer.new(@user)
+    else
+      render_resource_error(@user)
+    end
   end
 
   private
 
   def user_params
-    params.require(:data).require(:attributes).permit(:email, :name)
+    params.require(:data).require(:attributes).permit(:name)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery unless: -> { request.format.json? }
-
   def authenticate_admin_user!
     redirect_to root_path unless current_user&.admin?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery unless: -> { request.format.json? }
+
   def authenticate_admin_user!
     redirect_to root_path unless current_user&.admin?
   end

--- a/app/lib/docs/public/v1/docs/index.html
+++ b/app/lib/docs/public/v1/docs/index.html
@@ -474,7 +474,7 @@
 <td></td>
 </tr>
 <tr>
-<td>organization_title</td>
+<td>organization_name</td>
 <td>string</td>
 <td>Employer name</td>
 </tr>
@@ -493,7 +493,7 @@
         "attributes": {
             "email": "mickey@example.com",
             "name": "Mickey Mouse",
-            "organization_title": "Disneyland"
+            "organization_name": "Disneyland"
         }
     }
 }'</span>
@@ -518,7 +518,7 @@
 <td></td>
 </tr>
 <tr>
-<td>organization_title</td>
+<td>organization_name</td>
 <td>string</td>
 <td>Employer name</td>
 </tr>
@@ -529,14 +529,30 @@
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
     </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"4"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"3"</span><span class="p">,</span><span class="w">
         </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
         </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
             </span><span class="s2">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"mickey@example.com"</span><span class="p">,</span><span class="w">
-            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Mickey Mouse"</span><span class="p">,</span><span class="w">
-            </span><span class="s2">"organization_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Disneyland"</span><span class="w">
+            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Mickey Mouse"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"employer"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">}</span><span class="w">
         </span><span class="p">}</span><span class="w">
-    </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"included"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Disneyland"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre><h1 id='errors'>Errors</h1>
 <p>Errors are returned as an array with the following attributes:</p>

--- a/app/lib/docs/public/v1/docs/index.html
+++ b/app/lib/docs/public/v1/docs/index.html
@@ -243,6 +243,20 @@
                   </li>
               </ul>
           </li>
+          <li>
+            <a href="#users" class="toc-h1 toc-link" data-title="Users">Users</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#user-object" class="toc-h2 toc-link" data-title="User object">User object</a>
+                  </li>
+                  <li>
+                    <a href="#create-user" class="toc-h2 toc-link" data-title="Create user">Create user</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
+            <a href="#errors" class="toc-h1 toc-link" data-title="Errors">Errors</a>
+          </li>
       </ul>
         <ul class="toc-footer">
             <li><a href='https://github.com/lord/slate'>Documentation Powered by Slate</a></li>
@@ -438,6 +452,139 @@
                 </span><span class="s2">"occupation_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"ABLE SEAMAN"</span><span class="p">,</span><span class="w">
                 </span><span class="s2">"industry_title"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="w">
             </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">]</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h1 id='users'>Users</h1><h2 id='user-object'>User object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>email</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>organization_title</td>
+<td>string</td>
+<td>Employer name</td>
+</tr>
+</tbody></table>
+<h2 id='create-user'>Create user</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X POST <span class="se">\</span>
+  http://www.rapidskills.org/v1/users <span class="se">\</span>
+  -H <span class="s1">'Accept: application/json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": {
+        "type": "users",
+        "attributes": {
+            "email": "mickey@example.com",
+            "name": "Mickey Mouse",
+            "organization_title": "Disneyland"
+        }
+    }
+}'</span>
+</code></pre><h3 id='http-request'>HTTP Request</h3>
+<p><code>POST http://www.rapidskills.org/v1/users</code></p>
+<h3 id='query-parameters'>Query Parameters</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>email<br /><em>required</em></td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>organization_title</td>
+<td>string</td>
+<td>Employer name</td>
+</tr>
+</tbody></table>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"4"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"mickey@example.com"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Mickey Mouse"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"organization_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Disneyland"</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h1 id='errors'>Errors</h1>
+<p>Errors are returned as an array with the following attributes:</p>
+
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>status</td>
+<td>string</td>
+<td>HTTP status code</td>
+</tr>
+<tr>
+<td>detail</td>
+<td>string</td>
+<td>explanation of the problem</td>
+</tr>
+</tbody></table>
+
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X POST <span class="se">\</span>
+  http://www.rapidskills.org/v1/users <span class="se">\</span>
+  -H <span class="s1">'Accept: application/json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": {
+        "type": "users",
+        "attributes": {
+            "email": ""
+            "name": "Mickey Mouse"
+        }
+    }
+}'</span>
+</code></pre>
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"errors"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"status"</span><span class="p">:</span><span class="w"> </span><span class="s2">"422"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"detail"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Email can't be blank"</span><span class="w">
         </span><span class="p">}</span><span class="w">
     </span><span class="p">]</span><span class="w">
 </span><span class="p">}</span><span class="w">

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
 
   enum role: [:basic, :admin]
 
+  belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,6 @@ class User < ApplicationRecord
 
   belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports
+
+  delegate :title, to: :employer, prefix: true, allow_nil: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :trackable,
          :recoverable, :rememberable, :validatable
 
-  enum role: [:basic, :admin]
+  enum role: [:lead, :basic, :admin]
 
   belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,7 @@ class User < ApplicationRecord
   belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports
 
-  delegate :title, to: :employer, prefix: true, allow_nil: true
+  def organization_title
+    employer.title
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,4 @@ class User < ApplicationRecord
 
   belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports
-
-  def organization_title
-    employer.title
-  end
 end

--- a/app/serializers/api/v1/organization_serializer.rb
+++ b/app/serializers/api/v1/organization_serializer.rb
@@ -1,0 +1,4 @@
+class API::V1::OrganizationSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :title
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -2,5 +2,5 @@ class API::V1::UserSerializer
   include FastJsonapi::ObjectSerializer
   attributes :email,
              :name,
-             :employer_title
+             :organization_title
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,5 +1,6 @@
 class API::V1::UserSerializer
   include FastJsonapi::ObjectSerializer
   attributes :email,
-             :name
+             :name,
+             :employer_title
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,6 +1,7 @@
 class API::V1::UserSerializer
   include FastJsonapi::ObjectSerializer
   attributes :email,
-             :name,
-             :organization_title
+             :name
+
+  belongs_to :employer, serializer: API::V1::OrganizationSerializer, record_type: :organization
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,5 @@
+class API::V1::UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :email,
+             :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
       resources :occupations, only: [:index]
       resources :occupation_standards, only: [:index]
 
+      resources :users, only: [:create]
+
       authenticate :user, lambda { |u| u.admin? } do
         mount Docs::API, at: '/docs'
       end

--- a/db/migrate/20191104224300_add_employer_id_to_users.rb
+++ b/db/migrate/20191104224300_add_employer_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmployerIdToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :employer, foreign_key: { to_table: :organizations }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_24_212954) do
+ActiveRecord::Schema.define(version: 2019_11_04_224300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,8 +197,10 @@ ActiveRecord::Schema.define(version: 2019_10_24_212954) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.integer "role", default: 0, null: false
+    t.bigint "employer_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["employer_id"], name: "index_users_on_employer_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -227,4 +229,5 @@ ActiveRecord::Schema.define(version: 2019_10_24_212954) do
   add_foreign_key "standards_registrations", "occupation_standards"
   add_foreign_key "standards_registrations", "organizations"
   add_foreign_key "standards_registrations", "states"
+  add_foreign_key "users", "organizations", column: "employer_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 require 'faker'
 
 admin = User.where(email: 'admin@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :admin, name: 'Admin')
-user = User.where(email: 'foo@example.com').first_or_create!(password: 'password', password_confirmation: 'password', name: 'Foo Bob')
+user = User.where(email: 'foo@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :basic, name: 'Foo Bob')
 
 Rake::Task['occupations:import'].invoke
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -17,51 +17,83 @@ RSpec.describe API::V1::UsersController, type: :request do
 
     before { allow(SecureRandom).to receive(:uuid).and_return("password") }
 
-    context "with new email" do
-      it "creates new User record" do
-        expect {
-          post path, params: params
-        }.to change(User, :count).by(1)
+    context "with valid params" do
+      context "with new email" do
+        it "creates new User record" do
+          expect {
+            post path, params: params
+          }.to change(User, :count).by(1)
 
-        user = User.last
-        expect(user.email).to eq "foo@example.com"
-        expect(user.name).to eq "Mickey Mouse"
-        expect(user.valid_password?("password")).to be true
+          user = User.last
+          expect(user.email).to eq "foo@example.com"
+          expect(user.name).to eq "Mickey Mouse"
+          expect(user.valid_password?("password")).to be true
+        end
+
+        it "returns user resource" do
+          post path, params: params
+          user = User.last
+          expect(response).to have_http_status(:success)
+          expect(json["data"]["id"]).to eq user.id.to_s
+          expect(json["data"]["type"]).to eq "user"
+          expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+          expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+        end
       end
 
-      it "returns user resource" do
-        post path, params: params
-        user = User.last
-        expect(response).to have_http_status(:success)
-        expect(json["data"]["id"]).to eq user.id.to_s
-        expect(json["data"]["type"]).to eq "user"
-        expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
-        expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+      context "with email already in use" do
+        let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+
+        it "does not create new user record but updates user" do
+          expect {
+            post path, params: params
+          }.to_not change(User, :count)
+
+          user.reload
+          expect(user.email).to eq "foo@example.com"
+          expect(user.name).to eq "Mickey Mouse"
+          expect(user.valid_password?("supersecret")).to be true
+        end
+
+        it "returns user resource" do
+          post path, params: params
+          user = User.last
+          expect(response).to have_http_status(:success)
+          expect(json["data"]["id"]).to eq user.id.to_s
+          expect(json["data"]["type"]).to eq "user"
+          expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+          expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+        end
       end
     end
 
-    context "with email already in use" do
-      let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+    context "with invalid params" do
+      context "without email" do
+        let(:params) {
+          {
+            data: {
+              type: "users",
+              attributes: {
+                email: "",
+                name: "Mickey Mouse",
+              }
+            }
+          }
+        }
 
-      it "does not create new user record" do
-        expect {
+        it "does not create new User record" do
+          expect {
+            post path, params: params
+          }.to_not change(User, :count)
+        end
+
+        it "returns 422 with error message" do
           post path, params: params
-        }.to_not change(User, :count)
-
-        user.reload
-        expect(user.email).to eq "foo@example.com"
-        expect(user.name).to eq "Foo Bar"
-        expect(user.valid_password?("supersecret")).to be true
-      end
-
-      it "returns user resource" do
-        post path, params: params
-        user = User.last
-        expect(response).to have_http_status(:success)
-        expect(json["data"]["id"]).to eq user.id.to_s
-        expect(json["data"]["type"]).to eq "user"
-        expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
-        expect(json["data"]["attributes"]["name"]).to eq "Foo Bar"
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json["errors"].count).to eq 1
+          expect(json["errors"][0]["status"]).to eq "422"
+          expect(json["errors"][0]["detail"]).to eq "Email can't be blank"
+        end
       end
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             attributes: {
               email: "foo@example.com",
               name: "Mickey Mouse",
-              organization_name: "Acme Computing",
+              organization_title: "Acme Computing",
             }
           }
         }
@@ -44,7 +44,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(json["data"]["type"]).to eq "user"
             expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
             expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-            expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+            expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
           end
         end
 
@@ -71,7 +71,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(json["data"]["type"]).to eq "user"
             expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
             expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-            expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+            expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
           end
         end
       end
@@ -84,7 +84,7 @@ RSpec.describe API::V1::UsersController, type: :request do
               attributes: {
                 email: "foo@example.com",
                 name: "Mickey Mouse",
-                organization_name: "Acme Computing",
+                organization_title: "Acme Computing",
               }
             }
           }
@@ -107,7 +107,7 @@ RSpec.describe API::V1::UsersController, type: :request do
           expect(json["data"]["type"]).to eq "user"
           expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
           expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-          expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+          expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
         end
       end
 
@@ -138,7 +138,7 @@ RSpec.describe API::V1::UsersController, type: :request do
           expect(json["data"]["type"]).to eq "user"
           expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
           expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-          expect(json["data"]["attributes"]["employer_title"]).to be nil
+          expect(json["data"]["attributes"]["organization_title"]).to be nil
         end
       end
     end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(user.email).to eq "foo@example.com"
             expect(user.name).to eq "Mickey Mouse"
             expect(user.employer).to eq organization
+            expect(user.lead?).to be true
             expect(user.valid_password?("password")).to be true
           end
 
@@ -49,9 +50,9 @@ RSpec.describe API::V1::UsersController, type: :request do
         end
 
         context "with email already in use" do
-          let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+          let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar", role: :basic) }
 
-          it "does not create new user record but updates user" do
+          it "does not create new user record but updates some fields" do
             expect {
               post path, params: params
             }.to_not change(User, :count)
@@ -60,6 +61,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(user.email).to eq "foo@example.com"
             expect(user.name).to eq "Mickey Mouse"
             expect(user.employer).to eq organization
+            expect(user.basic?).to be true
             expect(user.valid_password?("supersecret")).to be true
           end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe API::V1::UsersController, type: :request do
             attributes: {
               email: "foo@example.com",
               name: "Mickey Mouse",
-              organization_title: "Acme Computing",
+              organization_name: "Acme Computing",
             }
           }
         }
@@ -45,7 +45,11 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(json["data"]["type"]).to eq "user"
             expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
             expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-            expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
+            expect(json["data"]["relationships"]["employer"]["data"]["id"]).to eq organization.id.to_s
+            expect(json["data"]["relationships"]["employer"]["data"]["type"]).to eq "organization"
+            expect(json["included"][0]["id"]).to eq organization.id.to_s
+            expect(json["included"][0]["type"]).to eq "organization"
+            expect(json["included"][0]["attributes"]["title"]).to eq "Acme Computing"
           end
         end
 
@@ -73,7 +77,11 @@ RSpec.describe API::V1::UsersController, type: :request do
             expect(json["data"]["type"]).to eq "user"
             expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
             expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-            expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
+            expect(json["data"]["relationships"]["employer"]["data"]["id"]).to eq organization.id.to_s
+            expect(json["data"]["relationships"]["employer"]["data"]["type"]).to eq "organization"
+            expect(json["included"][0]["id"]).to eq organization.id.to_s
+            expect(json["included"][0]["type"]).to eq "organization"
+            expect(json["included"][0]["attributes"]["title"]).to eq "Acme Computing"
           end
         end
       end
@@ -86,7 +94,7 @@ RSpec.describe API::V1::UsersController, type: :request do
               attributes: {
                 email: "foo@example.com",
                 name: "Mickey Mouse",
-                organization_title: "Acme Computing",
+                organization_name: "Acme Computing",
               }
             }
           }
@@ -104,12 +112,17 @@ RSpec.describe API::V1::UsersController, type: :request do
         it "returns user resource" do
           post path, params: params
           user = User.last
+          organization = Organization.last
           expect(response).to have_http_status(:success)
           expect(json["data"]["id"]).to eq user.id.to_s
           expect(json["data"]["type"]).to eq "user"
           expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
           expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-          expect(json["data"]["attributes"]["organization_title"]).to eq "Acme Computing"
+          expect(json["data"]["relationships"]["employer"]["data"]["id"]).to eq organization.id.to_s
+          expect(json["data"]["relationships"]["employer"]["data"]["type"]).to eq "organization"
+          expect(json["included"][0]["id"]).to eq organization.id.to_s
+          expect(json["included"][0]["type"]).to eq "organization"
+          expect(json["included"][0]["attributes"]["title"]).to eq "Acme Computing"
         end
       end
 
@@ -140,7 +153,8 @@ RSpec.describe API::V1::UsersController, type: :request do
           expect(json["data"]["type"]).to eq "user"
           expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
           expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
-          expect(json["data"]["attributes"]["organization_title"]).to be nil
+          expect(json["data"]["relationships"]["employer"]["data"]).to be nil
+          expect(json.has_key?("included")).to be false
         end
       end
     end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::UsersController, type: :request do
+  describe "POST #create" do
+    let(:path) { "/v1/users" }
+    let(:params) {
+      {
+        data: {
+          type: "users",
+          attributes: {
+            email: "foo@example.com",
+            name: "Mickey Mouse",
+          }
+        }
+      }
+    }
+
+    before { allow(SecureRandom).to receive(:uuid).and_return("password") }
+
+    context "with new email" do
+      it "creates new User record" do
+        expect {
+          post path, params: params
+        }.to change(User, :count).by(1)
+
+        user = User.last
+        expect(user.email).to eq "foo@example.com"
+        expect(user.name).to eq "Mickey Mouse"
+        expect(user.valid_password?("password")).to be true
+      end
+
+      it "returns user resource" do
+        post path, params: params
+        user = User.last
+        expect(response).to have_http_status(:success)
+        expect(json["data"]["id"]).to eq user.id.to_s
+        expect(json["data"]["type"]).to eq "user"
+        expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+        expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+      end
+    end
+
+    context "with email already in use" do
+      let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+
+      it "does not create new user record" do
+        expect {
+          post path, params: params
+        }.to_not change(User, :count)
+
+        user.reload
+        expect(user.email).to eq "foo@example.com"
+        expect(user.name).to eq "Foo Bar"
+        expect(user.valid_password?("supersecret")).to be true
+      end
+
+      it "returns user resource" do
+        post path, params: params
+        user = User.last
+        expect(response).to have_http_status(:success)
+        expect(json["data"]["id"]).to eq user.id.to_s
+        expect(json["data"]["type"]).to eq "user"
+        expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+        expect(json["data"]["attributes"]["name"]).to eq "Foo Bar"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -3,56 +3,100 @@ require 'rails_helper'
 RSpec.describe API::V1::UsersController, type: :request do
   describe "POST #create" do
     let(:path) { "/v1/users" }
-    let(:params) {
-      {
-        data: {
-          type: "users",
-          attributes: {
-            email: "foo@example.com",
-            name: "Mickey Mouse",
-          }
-        }
-      }
-    }
 
     before { allow(SecureRandom).to receive(:uuid).and_return("password") }
 
     context "with valid params" do
-      context "with new email" do
-        it "creates new User record" do
-          expect {
-            post path, params: params
-          }.to change(User, :count).by(1)
+      let(:params) {
+        {
+          data: {
+            type: "users",
+            attributes: {
+              email: "foo@example.com",
+              name: "Mickey Mouse",
+              organization_name: "Acme Computing",
+            }
+          }
+        }
+      }
 
-          user = User.last
-          expect(user.email).to eq "foo@example.com"
-          expect(user.name).to eq "Mickey Mouse"
-          expect(user.valid_password?("password")).to be true
+      context "with existing organization" do
+        let!(:organization) { create(:organization, title: "Acme Computing") }
+
+        context "with new email" do
+          it "creates new User record" do
+            expect {
+              post path, params: params
+            }.to change(User, :count).by(1)
+
+            user = User.last
+            expect(user.email).to eq "foo@example.com"
+            expect(user.name).to eq "Mickey Mouse"
+            expect(user.employer).to eq organization
+            expect(user.valid_password?("password")).to be true
+          end
+
+          it "returns user resource" do
+            post path, params: params
+            user = User.last
+            expect(response).to have_http_status(:success)
+            expect(json["data"]["id"]).to eq user.id.to_s
+            expect(json["data"]["type"]).to eq "user"
+            expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+            expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+            expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+          end
         end
 
-        it "returns user resource" do
-          post path, params: params
-          user = User.last
-          expect(response).to have_http_status(:success)
-          expect(json["data"]["id"]).to eq user.id.to_s
-          expect(json["data"]["type"]).to eq "user"
-          expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
-          expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+        context "with email already in use" do
+          let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+
+          it "does not create new user record but updates user" do
+            expect {
+              post path, params: params
+            }.to_not change(User, :count)
+
+            user.reload
+            expect(user.email).to eq "foo@example.com"
+            expect(user.name).to eq "Mickey Mouse"
+            expect(user.employer).to eq organization
+            expect(user.valid_password?("supersecret")).to be true
+          end
+
+          it "returns user resource" do
+            post path, params: params
+            user = User.last
+            expect(response).to have_http_status(:success)
+            expect(json["data"]["id"]).to eq user.id.to_s
+            expect(json["data"]["type"]).to eq "user"
+            expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+            expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+            expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+          end
         end
       end
 
-      context "with email already in use" do
-        let!(:user) { create(:user, email: "foo@example.com", name: "Foo Bar") }
+      context "with new organization" do
+        let(:params) {
+          {
+            data: {
+              type: "users",
+              attributes: {
+                email: "foo@example.com",
+                name: "Mickey Mouse",
+                organization_name: "Acme Computing",
+              }
+            }
+          }
+        }
 
-        it "does not create new user record but updates user" do
+        it "creates new Organization record" do
           expect {
             post path, params: params
-          }.to_not change(User, :count)
+          }.to change(Organization, :count).by(1)
 
-          user.reload
-          expect(user.email).to eq "foo@example.com"
-          expect(user.name).to eq "Mickey Mouse"
-          expect(user.valid_password?("supersecret")).to be true
+          organization = Organization.last
+          expect(organization.title).to eq "Acme Computing"
         end
 
         it "returns user resource" do
@@ -63,6 +107,38 @@ RSpec.describe API::V1::UsersController, type: :request do
           expect(json["data"]["type"]).to eq "user"
           expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
           expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+          expect(json["data"]["attributes"]["employer_title"]).to eq "Acme Computing"
+        end
+      end
+
+      context "with no organization" do
+        let(:params) {
+          {
+            data: {
+              type: "users",
+              attributes: {
+                email: "foo@example.com",
+                name: "Mickey Mouse",
+              }
+            }
+          }
+        }
+
+        it "does not create new Organization record" do
+          expect {
+            post path, params: params
+          }.to_not change(Organization, :count)
+        end
+
+        it "returns user resource" do
+          post path, params: params
+          user = User.last
+          expect(response).to have_http_status(:success)
+          expect(json["data"]["id"]).to eq user.id.to_s
+          expect(json["data"]["type"]).to eq "user"
+          expect(json["data"]["attributes"]["email"]).to eq "foo@example.com"
+          expect(json["data"]["attributes"]["name"]).to eq "Mickey Mouse"
+          expect(json["data"]["attributes"]["employer_title"]).to be nil
         end
       end
     end


### PR DESCRIPTION
closes #70 
closes #73 

## Description
- Add Employer association to user (organization)
- Add create user endpoint

## QA
Using Postman:
- [x] Create user through API endpoint ([see docs](https://rapid-skills-staging-pr-74.herokuapp.com/v1/docs/#create-user))
- [x] Create user without email, should get error
