### PR TITLE
Allow users to edit skill descriptions

### DIFF
--- a/app/controllers/api/v1/occupation_standard_skills_controller.rb
+++ b/app/controllers/api/v1/occupation_standard_skills_controller.rb
@@ -15,7 +15,7 @@ class API::V1::OccupationStandardSkillsController < API::V1::APIController
   end
 
   def update
-    authorize @oss
+    authorize [:api, :v1, @oss]
     skill = Skill.where(update_params).first_or_initialize(parent_skill: @oss.skill)
     if skill.save
       @oss.update(skill: skill)

--- a/app/controllers/api/v1/occupation_standard_skills_controller.rb
+++ b/app/controllers/api/v1/occupation_standard_skills_controller.rb
@@ -1,5 +1,7 @@
 class API::V1::OccupationStandardSkillsController < API::V1::APIController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, only: [:index, :show]
+
+  before_action :set_occupation_standard_skill, only: [:show, :update]
 
   def index
     @os = OccupationStandard.find(params[:occupation_standard_id])
@@ -9,7 +11,31 @@ class API::V1::OccupationStandardSkillsController < API::V1::APIController
   end
 
   def show
+    render_resource
+  end
+
+  def update
+    authorize @oss
+    skill = Skill.where(update_params).first_or_initialize(parent_skill: @oss.skill)
+    if skill.save
+      @oss.update(skill: skill)
+      render_resource
+    else
+      render_resource_error(skill)
+    end
+  end
+
+  private
+
+  def set_occupation_standard_skill
     @oss = OccupationStandardSkill.find(params[:id])
+  end
+
+  def update_params
+    params.require(:data).require(:attributes).permit(:description)
+  end
+
+  def render_resource
     options = { links: { self: @oss.url } }
     render json: API::V1::OccupationStandardSkillSerializer.new(@oss, options)
   end

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -7,13 +7,13 @@ class API::V1::OccupationStandardsController < API::V1::APIController
              .search(search_params.to_h)
              .order(id: :desc)
     options = { links: { self: api_v1_occupation_standards_url } }
-    render_object(@oss, options)
+    render_resource(@oss, options)
   end
 
   def show
     @os = OccupationStandard.find(params[:id])
     options = { links: { self: @os.url } }
-    render_object(@os, options)
+    render_resource(@os, options)
   end
 
   def create
@@ -23,7 +23,7 @@ class API::V1::OccupationStandardsController < API::V1::APIController
         creator_id: current_user.id,
         organization_id: current_user.employer_id,
       )
-      render_object(@os)
+      render_resource(@os)
     else
       @os = OccupationStandard.new
       @os.errors.add(:parent_occupation_standard_id, :invalid)
@@ -41,7 +41,7 @@ class API::V1::OccupationStandardsController < API::V1::APIController
     params.require(:data).require(:attributes).permit(:parent_occupation_standard_id)
   end
 
-  def render_object(record, options={})
+  def render_resource(record, options={})
     options[:include] = [
       :"occupation_standard_work_processes.occupation_standard_skills",
       :occupation_standard_skills,

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -3,11 +3,11 @@ class API::V1::OccupationStandardsController < API::V1::APIController
 
   def index
     @oss = OccupationStandard
-             .includes(:organization, :occupation, :industry, :pdf_attachment, :excel_attachment)
+             .includes(:organization, :occupation, :industry, :pdf_attachment, :excel_attachment, :occupation_standard_skills_with_no_work_process, :occupation_standard_work_processes)
              .search(search_params.to_h)
              .order(id: :desc)
     options = { links: { self: api_v1_occupation_standards_url } }
-    render json: API::V1::OccupationStandardSerializer.new(@oss, options)
+    render_object(@oss, options)
   end
 
   def show

--- a/app/lib/docs/public/api/v1/docs/index.html
+++ b/app/lib/docs/public/api/v1/docs/index.html
@@ -280,6 +280,23 @@
               </ul>
           </li>
           <li>
+            <a href="#skills" class="toc-h1 toc-link" data-title="Skills">Skills</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#skill-object" class="toc-h2 toc-link" data-title="Skill object">Skill object</a>
+                  </li>
+                  <li>
+                    <a href="#list-skills" class="toc-h2 toc-link" data-title="List skills">List skills</a>
+                  </li>
+                  <li>
+                    <a href="#retrieve-skill" class="toc-h2 toc-link" data-title="Retrieve skill">Retrieve skill</a>
+                  </li>
+                  <li>
+                    <a href="#update-skill" class="toc-h2 toc-link" data-title="Update skill">Update skill</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
             <a href="#errors" class="toc-h1 toc-link" data-title="Errors">Errors</a>
           </li>
       </ul>
@@ -867,6 +884,144 @@ resource passed in the relationships field.</p>
             </span><span class="p">}</span><span class="w">
         </span><span class="p">}</span><span class="w">
     </span><span class="p">]</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h1 id='skills'>Skills</h1><h2 id='skill-object'>Skill object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>description</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>parent_skill_id</td>
+<td>string</td>
+<td>ID of skill from which skill is derived</td>
+</tr>
+</tbody></table>
+<h2 id='list-skills'>List skills</h2>
+<p>This endpoint returns only skills that have no associated Work Process.</p>
+
+<blockquote>
+<p>Example requests</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X GET <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/occupation_standards/1/skills <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span>
+</code></pre><h3 id='http-request'>HTTP Request</h3>
+<p><code>GET http://www.rapidskills.org/api/v1/occupation_standards/:occupation_standard_id/skills</code></p>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"description"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Work under pressure"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"10"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"description"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Technical savvy"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">],</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/skills"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h2 id='retrieve-skill'>Retrieve skill</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X GET <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/skills/9 <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span>
+</code></pre><h3 id='http-request-2'>HTTP Request</h3>
+<p><code>GET http://www.rapidskills.org/api/v1/skills/:skill_id</code></p>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"description"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Work under pressure"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/skills/9"</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/skills/9"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h2 id='update-skill'>Update skill</h2>
+<p>User must be authorized to update the skill.</p>
+
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X PATCH <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/skills/9 <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MiwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGYvSlBlSjhsVDZ1YkhETFBiTVdBZ3VLZ1RQRWlLRHo2V3R4eHpyeVZJRVRaN3FCTmRUbHFlIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoianE3MmV0T1p2Yzd6SEdMdXF0ZHg1USJ9.RKLaV3yfDs5czwBEuVr-gZtUatCfZTJOkmzEkYCLhcA'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": {
+        "attributes": {
+            "description": "Assess client needs"
+        }
+    }
+}'</span>
+</code></pre><h3 id='http-request-3'>HTTP Request</h3>
+<p><code>PATCH http://www.rapidskills.org/api/v1/skills/:skill_id</code></p>
+<h3 id='query-parameters'>Query Parameters</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>description</td>
+<td>string</td>
+<td></td>
+</tr>
+</tbody></table>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"description"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Assess client needs"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/skills/9"</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/skills/9"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre><h1 id='errors'>Errors</h1>
 <p>Errors are returned as an array with the following attributes:</p>

--- a/app/lib/docs/public/api/v1/docs/index.html
+++ b/app/lib/docs/public/api/v1/docs/index.html
@@ -241,6 +241,22 @@
               </ul>
           </li>
           <li>
+            <a href="#industries" class="toc-h1 toc-link" data-title="Industries">Industries</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#industry-object" class="toc-h2 toc-link" data-title="Industry object">Industry object</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
+            <a href="#locations" class="toc-h1 toc-link" data-title="Locations">Locations</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#location-object" class="toc-h2 toc-link" data-title="Location object">Location object</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
             <a href="#occupations" class="toc-h1 toc-link" data-title="Occupations">Occupations</a>
               <ul class="toc-list-h2">
                   <li>
@@ -269,13 +285,10 @@
               </ul>
           </li>
           <li>
-            <a href="#users" class="toc-h1 toc-link" data-title="Users">Users</a>
+            <a href="#organizations" class="toc-h1 toc-link" data-title="Organizations">Organizations</a>
               <ul class="toc-list-h2">
                   <li>
-                    <a href="#user-object" class="toc-h2 toc-link" data-title="User object">User object</a>
-                  </li>
-                  <li>
-                    <a href="#create-user" class="toc-h2 toc-link" data-title="Create user">Create user</a>
+                    <a href="#organization-object" class="toc-h2 toc-link" data-title="Organization object">Organization object</a>
                   </li>
               </ul>
           </li>
@@ -293,6 +306,33 @@
                   </li>
                   <li>
                     <a href="#update-skill" class="toc-h2 toc-link" data-title="Update skill">Update skill</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
+            <a href="#states" class="toc-h1 toc-link" data-title="States">States</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#state-object" class="toc-h2 toc-link" data-title="State object">State object</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
+            <a href="#users" class="toc-h1 toc-link" data-title="Users">Users</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#user-object" class="toc-h2 toc-link" data-title="User object">User object</a>
+                  </li>
+                  <li>
+                    <a href="#create-user" class="toc-h2 toc-link" data-title="Create user">Create user</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
+            <a href="#work-processes" class="toc-h1 toc-link" data-title="Work Processes">Work Processes</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#work-process-object" class="toc-h2 toc-link" data-title="Work Process object">Work Process object</a>
                   </li>
               </ul>
           </li>
@@ -422,7 +462,7 @@ resource passed in the relationships field.</p>
 </tbody></table>
 
 <p>Returns HTTP status 202, accepted.</p>
-<h1 id='occupations'>Occupations</h1><h2 id='occupation-object'>Occupation object</h2><h3 id='attributes'>Attributes</h3>
+<h1 id='industries'>Industries</h1><h2 id='industry-object'>Industry object</h2><h3 id='attributes'>Attributes</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -436,12 +476,60 @@ resource passed in the relationships field.</p>
 <td></td>
 </tr>
 <tr>
-<td>rapids_code</td>
+<td>naics_code</td>
+<td>string</td>
+<td></td>
+</tr>
+</tbody></table>
+<h1 id='locations'>Locations</h1><h2 id='location-object'>Location object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>city</td>
 <td>string</td>
 <td></td>
 </tr>
 <tr>
+<td>organization_id</td>
+<td>integer</td>
+<td></td>
+</tr>
+<tr>
+<td>state_id</td>
+<td>integer</td>
+<td></td>
+</tr>
+<tr>
+<td>street_address</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>zip_code</td>
+<td>string</td>
+<td></td>
+</tr>
+</tbody></table>
+<h1 id='occupations'>Occupations</h1><h2 id='occupation-object'>Occupation object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
 <td>onet_code</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>rapids_code</td>
 <td>string</td>
 <td></td>
 </tr>
@@ -453,6 +541,11 @@ resource passed in the relationships field.</p>
 <tr>
 <td>term_length_max</td>
 <td>integer</td>
+<td></td>
+</tr>
+<tr>
+<td>title</td>
+<td>string</td>
 <td></td>
 </tr>
 <tr>
@@ -786,7 +879,7 @@ resource passed in the relationships field.</p>
         </span><span class="p">}</span><span class="w">
     </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
-</span></code></pre><h1 id='users'>Users</h1><h2 id='user-object'>User object</h2><h3 id='attributes'>Attributes</h3>
+</span></code></pre><h1 id='organizations'>Organizations</h1><h2 id='organization-object'>Organization object</h2><h3 id='attributes'>Attributes</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -795,97 +888,22 @@ resource passed in the relationships field.</p>
 </tr>
 </thead><tbody>
 <tr>
-<td>name</td>
+<td>logo_url</td>
 <td>string</td>
 <td></td>
 </tr>
 <tr>
-<td>email</td>
-<td>string</td>
+<td>registers_standards</td>
+<td>boolean</td>
 <td></td>
 </tr>
 <tr>
-<td>organization_name</td>
+<td>title</td>
 <td>string</td>
-<td>Employer name</td>
+<td></td>
 </tr>
 </tbody></table>
-<h2 id='create-user'>Create user</h2>
-<blockquote>
-<p>Example request</p>
-</blockquote>
-<pre class="highlight shell tab-shell"><code>curl -X POST <span class="se">\</span>
-  http://www.rapidskills.org/api/v1/users <span class="se">\</span>
-  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
-  -H <span class="s1">'Content-Type: application/vnd.api+json'</span> <span class="se">\</span>
-  -d <span class="s1">'{
-    "data": {
-        "type": "user",
-        "attributes": {
-            "email": "mickey@example.com",
-            "name": "Mickey Mouse",
-            "organization_name": "Disneyland"
-        }
-    }
-}'</span>
-</code></pre><h3 id='http-request'>HTTP Request</h3>
-<p><code>POST http://www.rapidskills.org/api/v1/users</code></p>
-<h3 id='query-parameters'>Query Parameters</h3>
-<table><thead>
-<tr>
-<th>Parameter</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead><tbody>
-<tr>
-<td>email<br /><em>required</em></td>
-<td>string</td>
-<td></td>
-</tr>
-<tr>
-<td>name</td>
-<td>string</td>
-<td></td>
-</tr>
-<tr>
-<td>organization_name</td>
-<td>string</td>
-<td>Employer name</td>
-</tr>
-</tbody></table>
-
-<blockquote>
-<p>Example response</p>
-</blockquote>
-<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
-    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"3"</span><span class="p">,</span><span class="w">
-        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
-        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-            </span><span class="s2">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"mickey@example.com"</span><span class="p">,</span><span class="w">
-            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Mickey Mouse"</span><span class="w">
-        </span><span class="p">},</span><span class="w">
-        </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-            </span><span class="s2">"employer"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-                    </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
-                    </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
-                </span><span class="p">}</span><span class="w">
-            </span><span class="p">}</span><span class="w">
-        </span><span class="p">}</span><span class="w">
-    </span><span class="p">},</span><span class="w">
-    </span><span class="s2">"included"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
-        </span><span class="p">{</span><span class="w">
-            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
-            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="p">,</span><span class="w">
-            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-                </span><span class="s2">"title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Disneyland"</span><span class="w">
-            </span><span class="p">}</span><span class="w">
-        </span><span class="p">}</span><span class="w">
-    </span><span class="p">]</span><span class="w">
-</span><span class="p">}</span><span class="w">
-</span></code></pre><h1 id='skills'>Skills</h1><h2 id='skill-object'>Skill object</h2><h3 id='attributes'>Attributes</h3>
+<h1 id='skills'>Skills</h1><h2 id='skill-object'>Skill object</h2><h3 id='attributes'>Attributes</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -902,6 +920,11 @@ resource passed in the relationships field.</p>
 <td>parent_skill_id</td>
 <td>string</td>
 <td>ID of skill from which skill is derived</td>
+</tr>
+<tr>
+<td>sort_order</td>
+<td>integer</td>
+<td>Ranking within occupation standard</td>
 </tr>
 </tbody></table>
 <h2 id='list-skills'>List skills</h2>
@@ -1023,7 +1046,154 @@ resource passed in the relationships field.</p>
         </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/skills/9"</span><span class="w">
     </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
-</span></code></pre><h1 id='errors'>Errors</h1>
+</span></code></pre><h1 id='states'>States</h1><h2 id='state-object'>State object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>long_name</td>
+<td>string</td>
+<td>name</td>
+</tr>
+<tr>
+<td>short_name</td>
+<td>integer</td>
+<td>abbreviation</td>
+</tr>
+</tbody></table>
+<h1 id='users'>Users</h1><h2 id='user-object'>User object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>name</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>email</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>organization_name</td>
+<td>string</td>
+<td>Employer name</td>
+</tr>
+</tbody></table>
+<h2 id='create-user'>Create user</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X POST <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/users <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": {
+        "type": "user",
+        "attributes": {
+            "email": "mickey@example.com",
+            "name": "Mickey Mouse",
+            "organization_name": "Disneyland"
+        }
+    }
+}'</span>
+</code></pre><h3 id='http-request'>HTTP Request</h3>
+<p><code>POST http://www.rapidskills.org/api/v1/users</code></p>
+<h3 id='query-parameters'>Query Parameters</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>email<br /><em>required</em></td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>name</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>organization_name</td>
+<td>string</td>
+<td>Employer name</td>
+</tr>
+</tbody></table>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"3"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"mickey@example.com"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Mickey Mouse"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"employer"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"included"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Disneyland"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">]</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h1 id='work-processes'>Work Processes</h1><h2 id='work-process-object'>Work Process object</h2><h3 id='attributes'>Attributes</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>description</td>
+<td>string</td>
+<td></td>
+</tr>
+<tr>
+<td>hours</td>
+<td>integer</td>
+<td>Number of required hours</td>
+</tr>
+<tr>
+<td>sort_order</td>
+<td>integer</td>
+<td>Ranking within occupation standard</td>
+</tr>
+<tr>
+<td>title</td>
+<td>string</td>
+<td></td>
+</tr>
+</tbody></table>
+<h1 id='errors'>Errors</h1>
 <p>Errors are returned as an array with the following attributes:</p>
 
 <table><thead>

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -50,8 +50,24 @@ class OccupationStandard < ApplicationRecord
           parent_occupation_standard: self,
         )
 
-        os.occupation_standard_work_processes = occupation_standard_work_processes.map(&:dup)
-        os.occupation_standard_skills = occupation_standard_skills.map(&:dup)
+        occupation_standard_work_processes.each do |oswp|
+          new_oswp = oswp.dup
+          new_oswp.update!(occupation_standard: os)
+
+          oswp.occupation_standard_skills.each do |oss|
+            new_oss = oss.dup
+            new_oss.update!(
+              occupation_standard: os,
+              occupation_standard_work_process: new_oswp,
+            )
+          end
+        end
+
+        # Catch any skills that are not linked to work processes
+        skills.each do |skill|
+          # Fail silently if occupation_standard_skill already exists
+          os.occupation_standard_skills.create(skill: skill)
+        end
 
         os
       end

--- a/app/policies/api/v1/occupation_standard_skill_policy.rb
+++ b/app/policies/api/v1/occupation_standard_skill_policy.rb
@@ -1,4 +1,4 @@
-class OccupationStandardSkillPolicy < ApplicationPolicy
+class API::V1::OccupationStandardSkillPolicy < ApplicationPolicy
   attr_reader :user, :oss
 
   def initialize(user, oss)

--- a/app/serializers/api/v1/occupation_standard_skill_serializer.rb
+++ b/app/serializers/api/v1/occupation_standard_skill_serializer.rb
@@ -2,6 +2,8 @@ class API::V1::OccupationStandardSkillSerializer
   include FastJsonapi::ObjectSerializer
   set_type :skill
 
+  link :self, :url
+
   attribute :description do |object|
     object.skill_description
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
         resources :occupation_standard_skills, path: "skills", only: [:index], controller: "occupation_standard_work_processes/occupation_standard_skills"
       end
 
-      resources :occupation_standard_skills, path: "skills", only: [:show]
+      resources :occupation_standard_skills, path: "skills", only: [:show, :update]
       resources :users, only: [:create]
 
       resources :sessions, only: [:create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,12 +7,13 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 require 'faker'
 
-admin = User.where(email: 'admin@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :admin, name: 'Admin')
-user = User.where(email: 'foo@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :basic, name: 'Foo Bob')
+organization = Organization.where(title: "Acme Computing").first_or_create!
+
+admin = User.where(email: 'admin@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :admin, name: 'Admin', employer: organization)
+user = User.where(email: 'foo@example.com').first_or_create!(password: 'password', password_confirmation: 'password', role: :basic, name: 'Foo Bob', employer: organization)
 
 Rake::Task['occupations:import'].invoke
 
-organization = Organization.where(title: "Acme Computing").first_or_create!
 
 occupation_standard = FrameworkStandard.create(
   creator: user,

--- a/spec/policies/api/v1/occupation_standard_skill_policy_spec.rb
+++ b/spec/policies/api/v1/occupation_standard_skill_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OccupationStandardSkillPolicy, type: :policy do
+RSpec.describe API::V1::OccupationStandardSkillPolicy, type: :policy do
   let(:os) { create(:occupation_standard) }
   let(:oss) { create(:occupation_standard_skill, occupation_standard: os) }
 

--- a/spec/requests/api/v1/occupation_standard_skills_spec.rb
+++ b/spec/requests/api/v1/occupation_standard_skills_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe API::V1::OccupationStandardSkillsController, type: :request do
       expect(json["data"]["id"]).to eq oss.id.to_s
       expect(json["data"]["type"]).to eq "skill"
       expect(json["data"]["attributes"]["description"]).to eq oss.skill.description
+      expect(json["data"]["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
     end
   end
 
@@ -83,6 +84,7 @@ RSpec.describe API::V1::OccupationStandardSkillsController, type: :request do
             expect(json["data"]["id"]).to eq oss.id.to_s
             expect(json["data"]["type"]).to eq "skill"
             expect(json["data"]["attributes"]["description"]).to eq "this is an updated desc"
+            expect(json["data"]["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
           end
         end
 
@@ -106,6 +108,7 @@ RSpec.describe API::V1::OccupationStandardSkillsController, type: :request do
             expect(json["data"]["id"]).to eq oss.id.to_s
             expect(json["data"]["type"]).to eq "skill"
             expect(json["data"]["attributes"]["description"]).to eq "this is an updated desc"
+            expect(json["data"]["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
           end
         end
       end
@@ -140,15 +143,6 @@ RSpec.describe API::V1::OccupationStandardSkillsController, type: :request do
 
     context "when user does not belong to occupation standard" do
       it_behaves_like "unauthorized", :patch
-    end
-
-    it "returns the correct data" do
-      get path
-      expect(response).to have_http_status(:success)
-      expect(json["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
-      expect(json["data"]["id"]).to eq oss.id.to_s
-      expect(json["data"]["type"]).to eq "skill"
-      expect(json["data"]["attributes"]["description"]).to eq oss.skill.description
     end
   end
 end

--- a/spec/requests/api/v1/occupation_standard_skills_spec.rb
+++ b/spec/requests/api/v1/occupation_standard_skills_spec.rb
@@ -26,8 +26,121 @@ RSpec.describe API::V1::OccupationStandardSkillsController, type: :request do
 
   describe "GET #show" do
     let(:path) { "/api/v1/skills/#{oss.id}" }
-
     let(:oss) { create(:occupation_standard_skill) }
+
+    it "returns the correct data" do
+      get path
+      expect(response).to have_http_status(:success)
+      expect(json["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
+      expect(json["data"]["id"]).to eq oss.id.to_s
+      expect(json["data"]["type"]).to eq "skill"
+      expect(json["data"]["attributes"]["description"]).to eq oss.skill.description
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:path) { "/api/v1/skills/#{oss.id}" }
+    let(:user) { create(:user) }
+    let(:os) { create(:occupation_standard) }
+    let!(:oss) { create(:occupation_standard_skill, occupation_standard: os) }
+    let(:user) { create(:user) }
+    let(:header) { auth_header(user) }
+    let(:params) {
+      {
+        data: {
+          type: "skill",
+          id: oss.id.to_s,
+          attributes: {
+            description: "this is an updated desc",
+          }
+        }
+      }
+    }
+
+    context "when user belongs to occupation_standard" do
+      let(:os) { create(:occupation_standard, creator: user) }
+
+      it_behaves_like "authorization", :patch
+
+      context "with valid parameters" do
+        context "when new skill name does not exist" do
+          it "creates a new skill and links skill to oss" do
+            original_skill = oss.skill
+            expect{
+              patch path, params: params, headers: header
+            }.to change(Skill, :count).by(1)
+            skill = Skill.last
+            expect(skill.description).to eq "this is an updated desc"
+            expect(skill.parent_skill).to eq original_skill
+            oss.reload
+            expect(oss.skill).to eq skill
+          end
+
+          it "returns correct response" do
+            patch path, params: params, headers: header
+            expect(response).to have_http_status(:success)
+            expect(json["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
+            expect(json["data"]["id"]).to eq oss.id.to_s
+            expect(json["data"]["type"]).to eq "skill"
+            expect(json["data"]["attributes"]["description"]).to eq "this is an updated desc"
+          end
+        end
+
+        context "when new skill name does exist" do
+          let(:parent) { create(:skill) }
+          let!(:skill) { create(:skill, description: "this is an updated desc", parent_skill: parent) }
+
+          it "does not create a new skill but links skill to oss" do
+            expect{
+              patch path, params: params, headers: header
+            }.to_not change(Skill, :count)
+            oss.reload
+            expect(oss.skill).to eq skill
+            expect(skill.reload.parent_skill).to eq parent
+          end
+
+          it "returns correct response" do
+            patch path, params: params, headers: header
+            expect(response).to have_http_status(:success)
+            expect(json["links"]["self"]).to eq api_v1_occupation_standard_skill_url(oss)
+            expect(json["data"]["id"]).to eq oss.id.to_s
+            expect(json["data"]["type"]).to eq "skill"
+            expect(json["data"]["attributes"]["description"]).to eq "this is an updated desc"
+          end
+        end
+      end
+
+      context "with invalid parameters" do
+        let(:params) {
+          {
+            data: {
+              type: "skill",
+              id: oss.id.to_s,
+              attributes: {
+                description: "",
+              }
+            }
+          }
+        }
+
+        it "does not create new skill" do
+          expect{
+            patch path, params: params, headers: header
+          }.to_not change(Skill, :count)
+        end
+
+        it "returns 422 with an error message" do
+          patch path, params: params, headers: header
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json["errors"][0]["status"]).to eq "422"
+          expect(json["errors"][0]["detail"]).to eq "Description can't be blank"
+        end
+      end
+    end
+
+    context "when user does not belong to occupation standard" do
+      it_behaves_like "unauthorized", :patch
+    end
 
     it "returns the correct data" do
       get path

--- a/spec/requests/api/v1/occupation_standards_spec.rb
+++ b/spec/requests/api/v1/occupation_standards_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe API::V1::OccupationStandardsController, type: :request do
       expect(json["data"][2]["attributes"]["occupation_title"]).to eq occupation.title
       expect(json["data"][2]["attributes"]["industry_title"]).to be nil
       expect(json["data"][2]["links"]["self"]).to eq api_v1_occupation_standard_url(os1)
+      expect(json["included"]).to_not be nil
 
       # With occupation_id parameter, returns matches
       get path, params: { occupation_id: occupation.id }
@@ -57,11 +58,13 @@ RSpec.describe API::V1::OccupationStandardsController, type: :request do
       expect(json["data"][1]["attributes"]["occupation_title"]).to eq occupation.title
       expect(json["data"][1]["attributes"]["industry_title"]).to be nil
       expect(json["data"][1]["links"]["self"]).to eq api_v1_occupation_standard_url(os1)
+      expect(json["included"]).to_not be nil
 
       # With bad occupation_id parameter, returns none
       get path, params: { occupation_id: 9999 }
       expect(response).to have_http_status(:success)
       expect(json["data"]).to be_empty
+      expect(json["included"]).to be_empty
     end
   end
 

--- a/spec/requests/api/v1/occupation_standards_spec.rb
+++ b/spec/requests/api/v1/occupation_standards_spec.rb
@@ -130,12 +130,18 @@ RSpec.describe API::V1::OccupationStandardsController, type: :request do
           attributes: {
             description: oss2.skill.description,
           }.stringify_keys,
+          links: {
+            self: api_v1_occupation_standard_skill_url(oss2),
+          }.stringify_keys,
         }.stringify_keys,
         {
           type: "skill",
           id: oss1.id.to_s,
           attributes: {
             description: oss1.skill.description,
+          }.stringify_keys,
+          links: {
+            self: api_v1_occupation_standard_skill_url(oss1),
           }.stringify_keys,
         }.stringify_keys,
       ]

--- a/spec/support/shared/status.rb
+++ b/spec/support/shared/status.rb
@@ -11,3 +11,10 @@ RSpec.shared_examples "authorization" do |method|
     expect(response).to have_http_status(:success)
   end
 end
+
+RSpec.shared_examples "unauthorized" do |method|
+  it "has unauthorized status" do
+    send(method, path, params: params, headers: header)
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
closes #3 

## Description

- Fix cloning method that didn't correctly handle skills that may not be linked to a work process
- Return `included` section when listing occupation_standards
- Users can update skill descriptions on occupation standards that belong to them

## QA
- [x] [Sign in](https://rapid-skills-edit-skill-c95fqc.herokuapp.com/users/sign_in) to UI as admin@example.com/password in order to view docs
- [x] In Postman, [sign in](https://rapid-skills-edit-skill-c95fqc.herokuapp.com/api/v1/docs/#authentication) user: foo@example.com/password
- [x]  Retrieve `access_token` and use it to [clone](https://rapid-skills-edit-skill-c95fqc.herokuapp.com/api/v1/docs/#clone-occupation-standard) an occupation_standard
- [x]  [Per docs](https://rapid-skills-edit-skill-c95fqc.herokuapp.com/api/v1/docs/#update-skill), update one of the skill's descriptions. 
- [x]  [Retrieve](https://rapid-skills-edit-skill-c95fqc.herokuapp.com/api/v1/docs/#retrieve-occupation-standard) occupation_standard, verify skill name has been updated
- [x]  Try to update skill to an empty string. Should get error.