### PR TITLE
Add favoriting feature

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -18,7 +18,7 @@ class API::V1::APIController < ApplicationController
         @user = User
                   .joins(:client_sessions)
                   .where(payload)
-                  .where(client_sessions: { identifier: @session_identifier })
+                  .where(client_sessions: { id: @session_identifier })
                   .first
       end
     end

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -8,6 +8,13 @@ class API::V1::FavoritesController < API::V1::APIController
     head :ok
   end
 
+  def destroy
+    authorize [:api, :v1, @target_user], :favorite?
+    os = OccupationStandard.find(object_params[:id])
+    Relationship.where(user: @target_user, occupation_standard: os).destroy_all
+    head :ok
+  end
+
   private
 
   def set_target_user

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,20 @@
+class API::V1::FavoritesController < API::V1::APIController
+  before_action :set_target_user
+
+  def create
+    authorize [:api, :v1, @target_user], :favorite?
+    os = OccupationStandard.find(object_params[:id])
+    Relationship.create(user: @target_user, occupation_standard: os)
+    head :ok
+  end
+
+  private
+
+  def set_target_user
+    @target_user = User.find(params[:id])
+  end
+
+  def object_params
+    params.require(:data).permit(:type, :id)
+  end
+end

--- a/app/controllers/api/v1/occupation_standards_controller.rb
+++ b/app/controllers/api/v1/occupation_standards_controller.rb
@@ -2,8 +2,7 @@ class API::V1::OccupationStandardsController < API::V1::APIController
   skip_before_action :authenticate, except: [:create]
 
   def index
-    @oss = OccupationStandard
-             .includes(:organization, :occupation, :industry, :pdf_attachment, :excel_attachment, :occupation_standard_skills_with_no_work_process, :occupation_standard_work_processes)
+    @oss = OccupationStandard.with_eager_loading
              .search(search_params.to_h)
              .order(id: :desc)
     options = { links: { self: api_v1_occupation_standards_url } }

--- a/app/controllers/api/v1/sessions/relationships_controller.rb
+++ b/app/controllers/api/v1/sessions/relationships_controller.rb
@@ -1,4 +1,4 @@
-class API::V1::Sessions::RelationshipsController < API::V1::APIController
+class API::V1::Sessions::RelationshipsController < API::V1::SessionsController
   before_action :set_client_session
 
   def user
@@ -10,12 +10,5 @@ class API::V1::Sessions::RelationshipsController < API::V1::APIController
       }
     }
     render json: API::V1::Session::Relationships::UserSerializer.new(@user, options)
-  end
-
-  private
-
-  def set_client_session
-    @session = ClientSession.find_by(id: params[:id])
-    head :not_found and return unless @session
   end
 end

--- a/app/controllers/api/v1/sessions/relationships_controller.rb
+++ b/app/controllers/api/v1/sessions/relationships_controller.rb
@@ -1,0 +1,21 @@
+class API::V1::Sessions::RelationshipsController < API::V1::APIController
+  before_action :set_client_session
+
+  def user
+    authorize [:api, :v1, @session]
+    options = {
+      links: {
+        self: @session.relationships_url('user'),
+        related: @session.related_url('user'),
+      }
+    }
+    render json: API::V1::Session::Relationships::UserSerializer.new(@user, options)
+  end
+
+  private
+
+  def set_client_session
+    @session = ClientSession.find_by(id: params[:id])
+    head :not_found and return unless @session
+  end
+end

--- a/app/controllers/api/v1/sessions/user_controller.rb
+++ b/app/controllers/api/v1/sessions/user_controller.rb
@@ -1,0 +1,16 @@
+class API::V1::Sessions::UserController < API::V1::APIController
+  before_action :set_client_session
+
+  def show
+    authorize [:api, :v1, @session]
+    options = { links: { self: @session.related_url('user') } }
+    render json: API::V1::UserSerializer.new(@user, options)
+  end
+
+  private
+
+  def set_client_session
+    @session = ClientSession.find_by(id: params[:client_session_id])
+    head :not_found and return unless @session
+  end
+end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -2,29 +2,42 @@ class API::V1::SessionsController < API::V1::APIController
   skip_before_action :authenticate, only: :create
 
   def create
-    @user = User.find_by(email: params[:data][:attributes][:email])
-    if @user && @user.valid_password?(params[:data][:attributes][:password])
-      token = @user.create_api_access_token!
-      render json: {
-        meta: {
-          access_token: token,
-          token_type: "Bearer",
-        }
-      }, status: :created
+    @user = User.find_by(email: create_params[:email])
+    if @user && @user.valid_password?(create_params[:password])
+      @session = @user.create_session!
+      render json: API::V1::SessionSerializer.new(@session, render_options),
+        status: :created
     else
-      render json: {
-        errors: [
-          {
-            status: "422",
-            detail: I18n.t("devise.failure.not_found_in_database", authentication_keys: :email),
-          }
-        ]
-      }, status: :unprocessable_entity
+      render_error(
+        status: :unprocessable_entity,
+        detail: I18n.t(
+          "devise.failure.not_found_in_database",
+          authentication_keys: :email,
+        ),
+      )
     end
+  end
+
+  def show
+    @session = ClientSession.find(@session_identifier)
+    render json: API::V1::SessionSerializer.new(@session, render_options)
   end
 
   def destroy
     @user.destroy_session!(@session_identifier)
     head :no_content
+  end
+
+  private
+
+  def create_params
+    params.require(:data).require(:attributes).permit(:email, :password)
+  end
+
+  def render_options
+    {
+      links: { self: @session.url },
+      meta: { access_token: @session.token, token_type: "Bearer" },
+    }
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,6 @@
 class API::V1::SessionsController < API::V1::APIController
   skip_before_action :authenticate, only: :create
+  before_action :set_client_session, only: :show
 
   def create
     @user = User.find_by(email: create_params[:email])
@@ -19,7 +20,7 @@ class API::V1::SessionsController < API::V1::APIController
   end
 
   def show
-    @session = ClientSession.find(@session_identifier)
+    authorize [:api, :v1, @session]
     render json: API::V1::SessionSerializer.new(@session, render_options)
   end
 
@@ -32,6 +33,11 @@ class API::V1::SessionsController < API::V1::APIController
 
   def create_params
     params.require(:data).require(:attributes).permit(:email, :password)
+  end
+
+  def set_client_session
+    @session = ClientSession.find_by(id: params[:id])
+    head :not_found and return unless @session
   end
 
   def render_options

--- a/app/controllers/api/v1/users/favorites_controller.rb
+++ b/app/controllers/api/v1/users/favorites_controller.rb
@@ -1,0 +1,9 @@
+class API::V1::Users::FavoritesController < API::V1::APIController
+  def index
+    @target_user = User.where(id: params[:user_id]).first_or_initialize
+    authorize [:api, :v1, @target_user], :favorite?
+    @favorites = @target_user.favorites.with_eager_loading
+    options = { links: { self: api_v1_user_favorites_url(@target_user) } }
+    render json: API::V1::OccupationStandardSerializer.new(@favorites, options)
+  end
+end

--- a/app/controllers/api/v1/users/favorites_controller.rb
+++ b/app/controllers/api/v1/users/favorites_controller.rb
@@ -1,9 +1,17 @@
 class API::V1::Users::FavoritesController < API::V1::APIController
+  before_action :set_target_user
+
   def index
-    @target_user = User.where(id: params[:user_id]).first_or_initialize
     authorize [:api, :v1, @target_user], :favorite?
     @favorites = @target_user.favorites.with_eager_loading
     options = { links: { self: api_v1_user_favorites_url(@target_user) } }
     render json: API::V1::OccupationStandardSerializer.new(@favorites, options)
+  end
+
+  private
+
+  def set_target_user
+    @target_user = User.find_by(id: params[:user_id])
+    head :not_found and return unless @target_user
   end
 end

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -1,4 +1,4 @@
-class API::V1::FavoritesController < API::V1::APIController
+class API::V1::Users::Relationships::FavoritesController < API::V1::APIController
   before_action :set_target_user
 
   def create

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -15,15 +15,19 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
 
   def create
     authorize [:api, :v1, @target_user], :favorite?
-    os = OccupationStandard.find(object_params[:id])
-    Relationship.create(user: @target_user, occupation_standard: os)
+    object_params.each do |object_param|
+      os = OccupationStandard.find(object_param[:id])
+      Relationship.create(user: @target_user, occupation_standard: os)
+    end
     head :ok
   end
 
   def destroy
     authorize [:api, :v1, @target_user], :favorite?
-    os = OccupationStandard.find(object_params[:id])
-    Relationship.where(user: @target_user, occupation_standard: os).destroy_all
+    object_params.each do |object_param|
+      os = OccupationStandard.find(object_param[:id])
+      Relationship.where(user: @target_user, occupation_standard: os).destroy_all
+    end
     head :ok
   end
 
@@ -34,6 +38,6 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
   end
 
   def object_params
-    params.require(:data).permit(:type, :id)
+    params.require(:data)
   end
 end

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -16,8 +16,8 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
   def create
     authorize [:api, :v1, @target_user], :favorite?
     object_params.each do |object_param|
-      os = OccupationStandard.find(object_param[:id])
-      Relationship.create(user: @target_user, occupation_standard: os)
+      os = OccupationStandard.find_by(id: object_param[:id])
+      Relationship.create(user: @target_user, occupation_standard: os) if os
     end
     head :ok
   end
@@ -25,8 +25,8 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
   def destroy
     authorize [:api, :v1, @target_user], :favorite?
     object_params.each do |object_param|
-      os = OccupationStandard.find(object_param[:id])
-      Relationship.where(user: @target_user, occupation_standard: os).destroy_all
+      os = OccupationStandard.find_by(id: object_param[:id])
+      Relationship.where(user: @target_user, occupation_standard: os).destroy_all if os
     end
     head :ok
   end

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -1,6 +1,18 @@
 class API::V1::Users::Relationships::FavoritesController < API::V1::APIController
   before_action :set_target_user
 
+  def index
+    authorize [:api, :v1, @target_user], :favorite?
+    @occupation_standards = @target_user.favorites
+    options = {
+      links: {
+        self: @target_user.relationships_url('favorites'),
+        related: @target_user.related_url('favorites'),
+      }
+    }
+    render json: API::V1::User::Relationships::OccupationStandardSerializer.new(@occupation_standards, options)
+  end
+
   def create
     authorize [:api, :v1, @target_user], :favorite?
     os = OccupationStandard.find(object_params[:id])

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -34,7 +34,8 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
   private
 
   def set_target_user
-    @target_user = User.where(id: params[:id]).first_or_initialize
+    @target_user = User.find_by(id: params[:id])
+    head :not_found and return unless @target_user
   end
 
   def object_params

--- a/app/controllers/api/v1/users/relationships/favorites_controller.rb
+++ b/app/controllers/api/v1/users/relationships/favorites_controller.rb
@@ -30,7 +30,7 @@ class API::V1::Users::Relationships::FavoritesController < API::V1::APIControlle
   private
 
   def set_target_user
-    @target_user = User.find(params[:id])
+    @target_user = User.where(id: params[:id]).first_or_initialize
   end
 
   def object_params

--- a/app/lib/docs/public/api/v1/docs/index.html
+++ b/app/lib/docs/public/api/v1/docs/index.html
@@ -230,6 +230,9 @@
                   <li>
                     <a href="#sign-out" class="toc-h2 toc-link" data-title="Sign out">Sign out</a>
                   </li>
+                  <li>
+                    <a href="#session-user" class="toc-h2 toc-link" data-title="Session user">Session user</a>
+                  </li>
               </ul>
           </li>
           <li>
@@ -441,14 +444,67 @@ changing the user password will invalidate the token.</p>
 </blockquote>
 <pre class="highlight shell tab-shell"><code>curl -X DELETE <span class="se">\</span>
   http://www.rapidskills.org/api/v1/sessions/ba204a5c-7f28-4d7f-9913-d2216e629364 <span class="se">\</span>
-  -H <span class="s1">'Accept: application/json'</span> <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
   -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiYmEyMDRhNWMtN2YyOC00ZDdmLTk5MTMtZDIyMTZlNjI5MzY0In0.JIuA_iuNrBkKlHBPB_FIptso2Es0P85WkIaLPVwiusM'</span> <span class="se">\</span>
   -H <span class="s1">'Content-Type: application/json'</span>
 </code></pre><h3 id='http-request-2'>HTTP Request</h3>
 <p><code>DELETE http://www.rapidskills.org/api/v1/sessions/:session_id</code></p>
 
 <p>Returns HTTP status 204, no content.</p>
-<h1 id='downloads'>Downloads</h1><h2 id='pdf-excel-generation'>PDF/Excel generation</h2>
+<h2 id='session-user'>Session user</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X GET <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/sessions/e016b27d-ada5-4691-b23b-059bdd616086/user <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiZTAxNmIyN2QtYWRhNS00NjkxLWIyM2ItMDU5YmRkNjE2MDg2In0.n4GrMeFezg1gYXh7TOn9Ra55viPHx6UTS2e8JD4z_UE'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span>
+</code></pre><h3 id='http-request-3'>HTTP Request</h3>
+<p><code>GET http://www.rapidskills.org/api/v1/sessions/:session_id/user</code></p>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"foo@example.com"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Foo Bar"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"role"</span><span class="p">:</span><span class="w"> </span><span class="s2">"lead"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"employer"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="s2">"favorites"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+                    </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"22"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="w">
+                    </span><span class="p">},</span><span class="w">
+                    </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">],</span><span class="w">
+                </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/users/1/relationships/favorites"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/users/1/favorites"</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/sessions/e016b27d-ada5-4691-b23b-059bdd616086/user"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h1 id='downloads'>Downloads</h1><h2 id='pdf-excel-generation'>PDF/Excel generation</h2>
 <p>This endpoint will trigger the PDF and/or Excel document generation for the
 resource passed in the relationships field.</p>
 

--- a/app/lib/docs/public/api/v1/docs/index.html
+++ b/app/lib/docs/public/api/v1/docs/index.html
@@ -249,6 +249,20 @@
               </ul>
           </li>
           <li>
+            <a href="#favorites" class="toc-h1 toc-link" data-title="Favorites">Favorites</a>
+              <ul class="toc-list-h2">
+                  <li>
+                    <a href="#list-favorites" class="toc-h2 toc-link" data-title="List favorites">List favorites</a>
+                  </li>
+                  <li>
+                    <a href="#create-favorite" class="toc-h2 toc-link" data-title="Create favorite">Create favorite</a>
+                  </li>
+                  <li>
+                    <a href="#delete-favorite" class="toc-h2 toc-link" data-title="Delete favorite">Delete favorite</a>
+                  </li>
+              </ul>
+          </li>
+          <li>
             <a href="#locations" class="toc-h1 toc-link" data-title="Locations">Locations</a>
               <ul class="toc-list-h2">
                   <li>
@@ -481,6 +495,284 @@ resource passed in the relationships field.</p>
 <td></td>
 </tr>
 </tbody></table>
+<h1 id='favorites'>Favorites</h1><h2 id='list-favorites'>List favorites</h2><h3 id='relationships-request'>Relationships request</h3>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X GET <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/users/1/relationships/favorites <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span> <span class="se">\</span>
+</code></pre><h3 id='http-request'>HTTP Request</h3>
+<p><code>GET http://www.rapidskills.org/api/v1/users/:user_id/relationships/favorites</code></p>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"22"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">],</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/users/1/relationships/favorites"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/users/1/favorites"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h3 id='full-request'>Full request</h3>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X GET <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/users/1/favorites <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/vnd.api+json'</span> <span class="se">\</span>
+</code></pre><h3 id='http-request-2'>HTTP Request</h3>
+<p><code>GET http://www.rapidskills.org/api/v1/users/:user_id/favorites</code></p>
+
+<blockquote>
+<p>Example response</p>
+</blockquote>
+<pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"22"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Community Health Nurse"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"organization_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Care New England - VNA of Care New England"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"occupation_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Community Health Nurse"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"industry_title"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_filename"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_url"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_created_at"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_filename"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_url"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_created_at"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"should_generate_attachments"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"work_processes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[],</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/relationships/work_processes"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/work_processes"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"skills"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"326"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="w">
+                        </span><span class="p">},</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"327"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="w">
+                        </span><span class="p">}</span><span class="w">
+                    </span><span class="p">],</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/relationships/skills"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/skills"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"occupation"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"401"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation"</span><span class="w">
+                    </span><span class="p">},</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/relationships/occupation"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupations/401"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"organization"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
+                    </span><span class="p">},</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22/relationships/organization"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/organizations/9"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/22"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation_standard"</span><span class="p">,</span><span class="w">
+            </span><span class="s2">"attributes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"International Associate"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"organization_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Acme Computing"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"occupation_title"</span><span class="p">:</span><span class="w"> </span><span class="s2">"ABLE SEAMAN"</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"industry_title"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_filename"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_url"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"pdf_created_at"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_filename"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_url"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"excel_created_at"</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span><span class="w">
+                </span><span class="s2">"should_generate_attachments"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"work_processes"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"work_process"</span><span class="w">
+                        </span><span class="p">},</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"work_process"</span><span class="w">
+                        </span><span class="p">},</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"3"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"work_process"</span><span class="w">
+                        </span><span class="p">}</span><span class="w">
+                    </span><span class="p">],</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/relationships/work_processes"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/work_processes"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"skills"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"9"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="w">
+                        </span><span class="p">},</span><span class="w">
+                        </span><span class="p">{</span><span class="w">
+                            </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"10"</span><span class="p">,</span><span class="w">
+                            </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"skill"</span><span class="w">
+                        </span><span class="p">}</span><span class="w">
+                    </span><span class="p">],</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/relationships/skills"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/skills"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"occupation"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"occupation"</span><span class="w">
+                    </span><span class="p">},</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/relationships/occupation"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupations/1"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"organization"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"organization"</span><span class="w">
+                    </span><span class="p">},</span><span class="w">
+                    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1/relationships/organization"</span><span class="p">,</span><span class="w">
+                        </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/organizations/1"</span><span class="w">
+                    </span><span class="p">}</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/occupation_standards/1"</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">],</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/users/1/favorites"</span><span class="w">
+    </span><span class="p">}</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre><h2 id='create-favorite'>Create favorite</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X POST <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/users/1/relationships/favorites <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiUEs4b2wwMzN3SlNmOF9VTHN2Z3A5dyJ9.mMmT03mUF8h1L7tlZ-MRXv0pO1YW7ta0wgRtaq3unJU'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": [
+        {
+            "type": "occupation_standard",
+            "id": "3"
+        }
+    ]
+}'</span>
+</code></pre><h3 id='http-request-3'>HTTP Request</h3>
+<p><code>POST http://www.rapidskills.org/api/v1/users/:user_id/relationships/favorites</code></p>
+<h3 id='query-parameters'>Query parameters</h3>
+<p>Array specifying type and id must be passed.</p>
+
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>type<br /><em>required</em></td>
+<td>string</td>
+<td>&quot;occupation_standard&quot;</td>
+</tr>
+<tr>
+<td>id<br /><em>required</em></td>
+<td>string</td>
+<td>ID of occupation standard to add as favorite</td>
+</tr>
+</tbody></table>
+
+<p>Returns HTTP status 200, OK.</p>
+<h2 id='delete-favorite'>Delete favorite</h2>
+<blockquote>
+<p>Example request</p>
+</blockquote>
+<pre class="highlight shell tab-shell"><code>curl -X DELETE <span class="se">\</span>
+  http://www.rapidskills.org/api/v1/users/1/relationships/favorites <span class="se">\</span>
+  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
+  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiUEs4b2wwMzN3SlNmOF9VTHN2Z3A5dyJ9.mMmT03mUF8h1L7tlZ-MRXv0pO1YW7ta0wgRtaq3unJU'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span> <span class="se">\</span>
+  -d <span class="s1">'{
+    "data": [
+        {
+            "type": "occupation_standard",
+            "id": "3"
+        }
+    ]
+}'</span>
+</code></pre><h3 id='http-request-4'>HTTP Request</h3>
+<p><code>DELETE http://www.rapidskills.org/api/v1/users/:user_id/relationships/favorites</code></p>
+<h3 id='query-parameters-2'>Query parameters</h3>
+<p>Array specifying type and id must be passed.</p>
+
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>type<br /><em>required</em></td>
+<td>string</td>
+<td>&quot;occupation_standard&quot;</td>
+</tr>
+<tr>
+<td>id<br /><em>required</em></td>
+<td>string</td>
+<td>ID of occupation standard to delete from favorites</td>
+</tr>
+</tbody></table>
+
+<p>Returns HTTP status 200, OK.</p>
 <h1 id='locations'>Locations</h1><h2 id='location-object'>Location object</h2><h3 id='attributes'>Attributes</h3>
 <table><thead>
 <tr>

--- a/app/lib/docs/public/api/v1/docs/index.html
+++ b/app/lib/docs/public/api/v1/docs/index.html
@@ -411,9 +411,28 @@ changing the user password will invalidate the token.</p>
 <p>Example response</p>
 </blockquote>
 <pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+    </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"ba204a5c-7f28-4d7f-9913-d2216e629364"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"session"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"relationships"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="s2">"user"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="s2">"data"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"1"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="w">
+                </span><span class="p">},</span><span class="w">
+                </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                    </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/sessions/ba204a5c-7f28-4d7f-9913-d2216e629364/relationships/user"</span><span class="p">,</span><span class="w">
+                    </span><span class="s2">"related"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/sessions/ba204a5c-7f28-4d7f-9913-d2216e629364/user"</span><span class="w">
+                </span><span class="p">}</span><span class="w">
+            </span><span class="p">}</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+    </span><span class="p">},</span><span class="w">
     </span><span class="s2">"meta"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-        </span><span class="s2">"access_token"</span><span class="p">:</span><span class="w"> </span><span class="s2">"eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJEY1QXZOQUh1S2VWZmVlWGovd3pUMS4wVlk4VmhtMmFiVnBkTllydmdJcENia2xqSkh0OUNHIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiaFRBSWNfQ2NDX2VHUlRaSnREZ1BudyJ9.5_2pUtK43EpvtqmAfTHeFrWm6Hp1Lkdq8p6XG0g0G4c"</span><span class="p">,</span><span class="w">
+        </span><span class="s2">"access_token"</span><span class="p">:</span><span class="w"> </span><span class="s2">"eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiYmEyMDRhNWMtN2YyOC00ZDdmLTk5MTMtZDIyMTZlNjI5MzY0In0.JIuA_iuNrBkKlHBPB_FIptso2Es0P85WkIaLPVwiusM"</span><span class="p">,</span><span class="w">
         </span><span class="s2">"token_type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Bearer"</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="s2">"links"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="s2">"self"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://www.rapidskills.org/api/v1/sessions/ba204a5c-7f28-4d7f-9913-d2216e629364"</span><span class="w">
     </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre><h2 id='sign-out'>Sign out</h2>
@@ -421,12 +440,12 @@ changing the user password will invalidate the token.</p>
 <p>Example request</p>
 </blockquote>
 <pre class="highlight shell tab-shell"><code>curl -X DELETE <span class="se">\</span>
-  http://www.rapidskills.org/api/v1/sessions <span class="se">\</span>
-  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJEY1QXZOQUh1S2VWZmVlWGovd3pUMS4wVlk4VmhtMmFiVnBkTllydmdJcENia2xqSkh0OUNHIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiaFRBSWNfQ2NDX2VHUlRaSnREZ1BudyJ9.5_2pUtK43EpvtqmAfTHeFrWm6Hp1Lkdq8p6XG0g0G4c'</span> <span class="se">\</span>
-  -H <span class="s1">'Accept: application/vnd.api+json'</span> <span class="se">\</span>
-  -H <span class="s1">'Content-Type: application/vnd.api+json'</span>
+  http://www.rapidskills.org/api/v1/sessions/ba204a5c-7f28-4d7f-9913-d2216e629364 <span class="se">\</span>
+  -H <span class="s1">'Accept: application/json'</span> <span class="se">\</span>
+  -H <span class="s1">'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW5jcnlwdGVkX3Bhc3N3b3JkIjoiJDJhJDExJGVtS0t3alFaTGVWcS5ScEtIUlpmUi5yWFY5WDcyYm5wc2VjaHhqeHVnNVY1Q1B1VXJ4cDhpIiwic2Vzc2lvbl9pZGVudGlmaWVyIjoiYmEyMDRhNWMtN2YyOC00ZDdmLTk5MTMtZDIyMTZlNjI5MzY0In0.JIuA_iuNrBkKlHBPB_FIptso2Es0P85WkIaLPVwiusM'</span> <span class="se">\</span>
+  -H <span class="s1">'Content-Type: application/json'</span>
 </code></pre><h3 id='http-request-2'>HTTP Request</h3>
-<p><code>DELETE http://www.rapidskills.org/api/v1/sessions</code></p>
+<p><code>DELETE http://www.rapidskills.org/api/v1/sessions/:session_id</code></p>
 
 <p>Returns HTTP status 204, no content.</p>
 <h1 id='downloads'>Downloads</h1><h2 id='pdf-excel-generation'>PDF/Excel generation</h2>

--- a/app/models/client_session.rb
+++ b/app/models/client_session.rb
@@ -1,3 +1,17 @@
 class ClientSession < ApplicationRecord
   belongs_to :user
+
+  def create_api_access_token!
+    JsonWebToken.encode(authentication_payload)
+  end
+
+  private
+
+  def authentication_payload
+    {
+      id: user_id,
+      encrypted_password: user.encrypted_password,
+      session_identifier: identifier,
+    }
+  end
 end

--- a/app/models/client_session.rb
+++ b/app/models/client_session.rb
@@ -11,7 +11,7 @@ class ClientSession < ApplicationRecord
     {
       id: user_id,
       encrypted_password: user.encrypted_password,
-      session_identifier: identifier,
+      session_identifier: id,
     }
   end
 end

--- a/app/models/client_session.rb
+++ b/app/models/client_session.rb
@@ -1,7 +1,7 @@
 class ClientSession < ApplicationRecord
   belongs_to :user
 
-  def create_api_access_token!
+  def token
     JsonWebToken.encode(authentication_payload)
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -28,6 +28,8 @@ class OccupationStandard < ApplicationRecord
 
   scope :occupation, ->(occupation_id) { where(occupation_id: occupation_id) if occupation_id.present? }
 
+  scope :with_eager_loading, -> { includes(:organization, :occupation, :industry, :pdf_attachment, :excel_attachment, :occupation_standard_skills_with_no_work_process, :occupation_standard_work_processes) }
+
   CSV_HEADERS = %w(rapids_code onet_code organization_title occupation_standard_title type work_process_title work_process_description work_process_hours work_process_sort skill skill_sort).freeze
 
   def occupation_standard_skills_with_no_work_process_ids

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+class Relationship < ApplicationRecord
+  belongs_to :user
+  belongs_to :occupation_standard
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,6 @@
 class Relationship < ApplicationRecord
   belongs_to :user
   belongs_to :occupation_standard
+
+  validates :occupation_standard, uniqueness: { scope: :user }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,19 +13,17 @@ class User < ApplicationRecord
   has_many :favorites, -> { order(id: :desc) }, through: :relationships,
     class_name: 'OccupationStandard', source: :occupation_standard
 
-  class << self
-    def new_token
-      SecureRandom.urlsafe_base64
-    end
-  end
-
   def create_api_access_token!
     client_session = create_session!
     client_session.token
   end
 
+  def create_session!
+    client_sessions.create
+  end
+
   def destroy_session!(session_identifier)
-    client_sessions.where(identifier: session_identifier).destroy_all
+    client_sessions.where(id: session_identifier).destroy_all
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,9 @@ class User < ApplicationRecord
   belongs_to :employer, class_name: 'Organization', optional: true
   has_many :data_imports
   has_many :client_sessions
+  has_many :relationships
+  has_many :favorites, through: :relationships,
+    class_name: 'OccupationStandard', source: :occupation_standard
 
   class << self
     def new_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,8 @@ class User < ApplicationRecord
   end
 
   def create_api_access_token!
-    session_identifier = User.new_token
-    client_sessions.create(identifier: session_identifier)
-    JsonWebToken.encode(authentication_payload(session_identifier))
+    client_session = create_session!
+    client_session.create_api_access_token!
   end
 
   def destroy_session!(session_identifier)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :data_imports
   has_many :client_sessions
   has_many :relationships
-  has_many :favorites, through: :relationships,
+  has_many :favorites, -> { order(id: :desc) }, through: :relationships,
     class_name: 'OccupationStandard', source: :occupation_standard
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
 
   def create_api_access_token!
     client_session = create_session!
-    client_session.create_api_access_token!
+    client_session.token
   end
 
   def destroy_session!(session_identifier)

--- a/app/policies/api/v1/client_session_policy.rb
+++ b/app/policies/api/v1/client_session_policy.rb
@@ -9,4 +9,8 @@ class API::V1::ClientSessionPolicy < ApplicationPolicy
   def user?
     client_session.user == user
   end
+
+  def show?
+    user?
+  end
 end

--- a/app/policies/api/v1/client_session_policy.rb
+++ b/app/policies/api/v1/client_session_policy.rb
@@ -1,0 +1,12 @@
+class API::V1::ClientSessionPolicy < ApplicationPolicy
+  attr_reader :user, :client_session
+
+  def initialize(user, client_session)
+    @user = user
+    @client_session = client_session
+  end
+
+  def user?
+    client_session.user == user
+  end
+end

--- a/app/policies/api/v1/user_policy.rb
+++ b/app/policies/api/v1/user_policy.rb
@@ -1,0 +1,12 @@
+class API::V1::UserPolicy < ApplicationPolicy
+  attr_reader :user, :target_user
+
+  def initialize(user, target_user)
+    @user = user
+    @target_user = target_user
+  end
+
+  def favorite?
+    user == target_user
+  end
+end

--- a/app/serializers/api/v1/session/relationships/user_serializer.rb
+++ b/app/serializers/api/v1/session/relationships/user_serializer.rb
@@ -1,0 +1,3 @@
+class API::V1::Session::Relationships::UserSerializer
+  include FastJsonapi::ObjectSerializer
+end

--- a/app/serializers/api/v1/session_serializer.rb
+++ b/app/serializers/api/v1/session_serializer.rb
@@ -1,0 +1,10 @@
+class API::V1::SessionSerializer
+  include FastJsonapi::ObjectSerializer
+  set_type :session
+
+  belongs_to :user,
+    links: {
+      self: ->(object) { object.relationships_url('user') },
+      related: ->(object) { object.related_url('user') },
+    }
+end

--- a/app/serializers/api/v1/user/relationships/occupation_standard_serializer.rb
+++ b/app/serializers/api/v1/user/relationships/occupation_standard_serializer.rb
@@ -1,0 +1,3 @@
+class API::V1::User::Relationships::OccupationStandardSerializer
+  include FastJsonapi::ObjectSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -4,5 +4,15 @@ class API::V1::UserSerializer
              :name,
              :role
 
-  belongs_to :employer, serializer: API::V1::OrganizationSerializer, record_type: :organization
+  belongs_to :employer,
+    serializer: API::V1::OrganizationSerializer,
+    record_type: :organization
+
+  has_many :favorites,
+    serializer: API::V1::OccupationStandardSerializer,
+    record_type: :occupation_standard,
+    links: {
+      self: ->(object) { object.relationships_url('favorites') },
+      related: ->(object) { object.related_url('favorites') },
+    }
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,7 +1,8 @@
 class API::V1::UserSerializer
   include FastJsonapi::ObjectSerializer
   attributes :email,
-             :name
+             :name,
+             :role
 
   belongs_to :employer, serializer: API::V1::OrganizationSerializer, record_type: :organization
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,8 +35,10 @@ Rails.application.routes.draw do
       resources :organizations, only: [:show]
       resources :users, only: [:create] do
         member do
+          get "relationships/favorites", to: "users/relationships/favorites#index"
           post "relationships/favorites", to: "users/relationships/favorites#create"
           delete "relationships/favorites", to: "users/relationships/favorites#destroy"
+          resources :favorites, controller: "users/favorites", only: [:index], as: :user_favorites
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ Rails.application.routes.draw do
           get "relationships/favorites", to: "users/relationships/favorites#index"
           post "relationships/favorites", to: "users/relationships/favorites#create"
           delete "relationships/favorites", to: "users/relationships/favorites#destroy"
-          resources :favorites, controller: "users/favorites", only: [:index], as: :user_favorites
         end
       end
 
@@ -46,6 +45,7 @@ Rails.application.routes.draw do
       delete "sessions", to: "sessions#destroy"
 
       resources :downloads, only: [:create]
+      resources :user_favorites, only: [:index], controller: "favorites", path: "favorites"
 
       authenticate :user, lambda { |u| u.admin? } do
         mount Docs::API, at: '/docs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,13 +39,13 @@ Rails.application.routes.draw do
           post "relationships/favorites", to: "users/relationships/favorites#create"
           delete "relationships/favorites", to: "users/relationships/favorites#destroy"
         end
+        resources :favorites, only: [:index], controller: "users/favorites"
       end
 
       resources :sessions, only: [:create]
       delete "sessions", to: "sessions#destroy"
 
       resources :downloads, only: [:create]
-      resources :user_favorites, only: [:index], controller: "favorites", path: "favorites"
 
       authenticate :user, lambda { |u| u.admin? } do
         mount Docs::API, at: '/docs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,12 @@ Rails.application.routes.draw do
         resources :favorites, only: [:index], controller: "users/favorites"
       end
 
-      resources :sessions, only: [:create]
-      delete "sessions", to: "sessions#destroy"
+      resources :client_sessions, path: "sessions", only: [:create, :destroy, :show], controller: "sessions" do
+        member do
+          get "relationships/user", to: "sessions/relationships#user"
+        end
+        resource :user, only: [:show], controller: "sessions/user"
+      end
 
       resources :downloads, only: [:create]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,11 @@ Rails.application.routes.draw do
 
       resources :occupation_standard_skills, path: "skills", only: [:show, :update]
       resources :organizations, only: [:show]
-      resources :users, only: [:create]
+      resources :users, only: [:create] do
+        member do
+          post "relationships/favorites", to: "favorites#create"
+        end
+      end
 
       resources :sessions, only: [:create]
       delete "sessions", to: "sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       resources :users, only: [:create] do
         member do
           post "relationships/favorites", to: "favorites#create"
+          delete "relationships/favorites", to: "favorites#destroy"
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,8 +35,8 @@ Rails.application.routes.draw do
       resources :organizations, only: [:show]
       resources :users, only: [:create] do
         member do
-          post "relationships/favorites", to: "favorites#create"
-          delete "relationships/favorites", to: "favorites#destroy"
+          post "relationships/favorites", to: "users/relationships/favorites#create"
+          delete "relationships/favorites", to: "users/relationships/favorites#destroy"
         end
       end
 

--- a/db/migrate/20191115155251_create_relationships.rb
+++ b/db/migrate/20191115155251_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :occupation_standard, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191216175000_drop_client_sessions_table.rb
+++ b/db/migrate/20191216175000_drop_client_sessions_table.rb
@@ -1,0 +1,14 @@
+class DropClientSessionsTable < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :client_sessions
+  end
+
+  def down
+    create_table :client_sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :identifier
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191216180305_enable_uuids.rb
+++ b/db/migrate/20191216180305_enable_uuids.rb
@@ -1,0 +1,5 @@
+class EnableUuids < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20191216180418_create_client_sessions_table_with_uuid.rb
+++ b/db/migrate/20191216180418_create_client_sessions_table_with_uuid.rb
@@ -1,0 +1,9 @@
+class CreateClientSessionsTableWithUuid < ActiveRecord::Migration[6.0]
+  def change
+    create_table :client_sessions, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_175000) do
+ActiveRecord::Schema.define(version: 2019_12_16_180305) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_164043) do
+ActiveRecord::Schema.define(version: 2019_12_16_175000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,14 +48,6 @@ ActiveRecord::Schema.define(version: 2019_12_06_164043) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "client_sessions", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "identifier"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_client_sessions_on_user_id"
   end
 
   create_table "data_imports", force: :cascade do |t|
@@ -231,7 +223,6 @@ ActiveRecord::Schema.define(version: 2019_12_06_164043) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "client_sessions", "users"
   add_foreign_key "data_imports", "users"
   add_foreign_key "locations", "organizations"
   add_foreign_key "locations", "states"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -157,6 +157,15 @@ ActiveRecord::Schema.define(version: 2019_12_06_164043) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "occupation_standard_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["occupation_standard_id"], name: "index_relationships_on_occupation_standard_id"
+    t.index ["user_id"], name: "index_relationships_on_user_id"
+  end
+
   create_table "skills", force: :cascade do |t|
     t.text "description"
     t.integer "usage_count"
@@ -237,6 +246,8 @@ ActiveRecord::Schema.define(version: 2019_12_06_164043) do
   add_foreign_key "occupation_standards", "organizations"
   add_foreign_key "occupation_standards", "states", column: "registration_state_id"
   add_foreign_key "occupation_standards", "users", column: "creator_id"
+  add_foreign_key "relationships", "occupation_standards"
+  add_foreign_key "relationships", "users"
   add_foreign_key "skills", "skills", column: "parent_skill_id"
   add_foreign_key "standards_registrations", "occupation_standards"
   add_foreign_key "standards_registrations", "organizations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_180305) do
+ActiveRecord::Schema.define(version: 2019_12_16_180418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -49,6 +49,13 @@ ActiveRecord::Schema.define(version: 2019_12_16_180305) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "client_sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_client_sessions_on_user_id"
   end
 
   create_table "data_imports", force: :cascade do |t|
@@ -224,6 +231,7 @@ ActiveRecord::Schema.define(version: 2019_12_16_180305) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "client_sessions", "users"
   add_foreign_key "data_imports", "users"
   add_foreign_key "locations", "organizations"
   add_foreign_key "locations", "states"

--- a/spec/factories/client_sessions.rb
+++ b/spec/factories/client_sessions.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :client_session do
     user
-    identifier { SecureRandom.urlsafe_base64 }
   end
 end

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    user
+    occupation_standard
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "supersecret" }
-    name { "MyString" }
+    name { Faker::Name.name }
 
     factory :admin do
       role { :admin }

--- a/spec/models/client_session_spec.rb
+++ b/spec/models/client_session_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ClientSession, type: :model do
     expect(client_session.valid?).to be true
   end
 
-  describe "#create_api_access_token!" do
+  describe "#token" do
     let(:client_session) { create(:client_session) }
     let(:user) { client_session.user }
 
@@ -15,7 +15,7 @@ RSpec.describe ClientSession, type: :model do
     end
 
     it "returns jwt token" do
-      jwt = client_session.create_api_access_token!
+      jwt = client_session.token
       expect(jwt).to eq "jwt123"
     end
   end

--- a/spec/models/client_session_spec.rb
+++ b/spec/models/client_session_spec.rb
@@ -5,4 +5,18 @@ RSpec.describe ClientSession, type: :model do
     client_session = build(:client_session)
     expect(client_session.valid?).to be true
   end
+
+  describe "#create_api_access_token!" do
+    let(:client_session) { create(:client_session) }
+    let(:user) { client_session.user }
+
+    before do
+      allow(JsonWebToken).to receive(:encode).with(id: user.id, encrypted_password: user.encrypted_password, session_identifier: client_session.identifier).and_return("jwt123")
+    end
+
+    it "returns jwt token" do
+      jwt = client_session.create_api_access_token!
+      expect(jwt).to eq "jwt123"
+    end
+  end
 end

--- a/spec/models/client_session_spec.rb
+++ b/spec/models/client_session_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ClientSession, type: :model do
     let(:user) { client_session.user }
 
     before do
-      allow(JsonWebToken).to receive(:encode).with(id: user.id, encrypted_password: user.encrypted_password, session_identifier: client_session.identifier).and_return("jwt123")
+      allow(JsonWebToken).to receive(:encode).with(id: user.id, encrypted_password: user.encrypted_password, session_identifier: client_session.id).and_return("jwt123")
     end
 
     it "returns jwt token" do

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  it "has a valid factory" do
+    r = build(:relationship)
+    expect(r.valid?).to be true
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe User, type: :model do
     expect(new_user.valid?).to be false
   end
 
+  describe "#favorites" do
+    it "links through relationships table" do
+      user = create(:user)
+      os = create(:occupation_standard)
+      create(:relationship, occupation_standard: os, user: user)
+      expect(user.favorites).to eq [os]
+    end
+  end
+
   describe ".new_token" do
     it "returns url safe base64 string" do
       expect(User.new_token).to be_a(String)

--- a/spec/requests/api/v1/favorites_spec.rb
+++ b/spec/requests/api/v1/favorites_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe API::V1::FavoritesController, type: :request do
 
       it_behaves_like "authorization", :post
 
-      context "when updating own favorite" do
+      context "when adding own favorite" do
         context "when occupation_standard is not already favorited" do
           it "creates a new relationship record" do
             expect{
@@ -48,8 +48,63 @@ RSpec.describe API::V1::FavoritesController, type: :request do
         end
       end
 
-      context "when updating favorite for someone else" do
+      context "when adding favorite for someone else" do
         it_behaves_like "unauthorized", :post do
+          let(:header) { auth_header(create(:user)) }
+        end
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:path) { "/api/v1/users/#{user.id}/relationships/favorites" }
+
+    context "with valid params" do
+      let(:os) { create(:occupation_standard) }
+      let(:params) {
+        {
+          data: {
+            type: "occupation_standard",
+            id: os.id.to_s,
+          }
+        }
+      }
+      let(:user) { create(:user) }
+      let(:header) { auth_header(user) }
+
+      it_behaves_like "authorization", :delete
+
+      context "when deleting own favorite" do
+        context "when occupation_standard is favorited" do
+          before { user.favorites << os }
+
+          it "deletes a relationship record" do
+            expect{
+              delete path, params: params, headers: header
+            }.to change(Relationship, :count).by(-1)
+          end
+
+          it "removes favorite and returns success" do
+            delete path, params: params, headers: header
+            expect(response).to have_http_status(:success)
+            user.reload
+            expect(user.favorites).to be_empty
+          end
+        end
+
+        context "when occupation_standard is not already favorited" do
+          it "does not delete a relationship record" do
+            expect{
+              delete path, params: params, headers: header
+            }.to_not change(Relationship, :count)
+          end
+
+          it_behaves_like "success", :delete
+        end
+      end
+
+      context "when deleting favorite for someone else" do
+        it_behaves_like "unauthorized", :delete do
           let(:header) { auth_header(create(:user)) }
         end
       end

--- a/spec/requests/api/v1/favorites_spec.rb
+++ b/spec/requests/api/v1/favorites_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::FavoritesController, type: :request do
+  describe "POST #create" do
+    let(:path) { "/api/v1/users/#{user.id}/relationships/favorites" }
+
+    context "with valid params" do
+      let(:os) { create(:occupation_standard) }
+      let(:params) {
+        {
+          data: {
+            type: "occupation_standard",
+            id: os.id.to_s,
+          }
+        }
+      }
+      let(:user) { create(:user) }
+      let(:header) { auth_header(user) }
+
+      it_behaves_like "authorization", :post
+
+      context "when updating own favorite" do
+        context "when occupation_standard is not already favorited" do
+          it "creates a new relationship record" do
+            expect{
+              post path, params: params, headers: header
+            }.to change(Relationship, :count).by(1)
+          end
+
+          it "sets favorite and returns success" do
+            post path, params: params, headers: header
+            expect(response).to have_http_status(:success)
+            user.reload
+            expect(user.favorites).to eq [os]
+          end
+        end
+
+        context "when occupation_standard is already favorited" do
+          before { user.favorites << os }
+
+          it "does not create a new relationship record" do
+            expect{
+              post path, params: params, headers: header
+            }.to_not change(Relationship, :count)
+          end
+
+          it_behaves_like "success", :post
+        end
+      end
+
+      context "when updating favorite for someone else" do
+        it_behaves_like "unauthorized", :post do
+          let(:header) { auth_header(create(:user)) }
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sessions/relationships_spec.rb
+++ b/spec/requests/api/v1/sessions/relationships_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::Sessions::RelationshipsController, type: :request do
+  describe "GET #user" do
+    let(:path) { "/api/v1/sessions/#{cs.id}/relationships/user" }
+    let(:cs) { create(:client_session) }
+    let(:user) { cs.user }
+    let(:params) { {} }
+    let(:header) { auth_header(user) }
+
+    context "when session belongs to user" do
+      it_behaves_like "authorization", :get
+
+      it "returns the correct data" do
+        get path, headers: header
+        expect(response).to have_http_status(:success)
+        expect(json["links"]["self"]).to eq relationships_user_api_v1_client_session_url(cs)
+        expect(json["links"]["related"]).to eq api_v1_client_session_user_url(cs)
+        expect(json["data"]["type"]).to eq "user"
+        expect(json["data"]["id"]).to eq user.id.to_s
+      end
+    end
+
+    context "when session does not belong to user" do
+      it_behaves_like "unauthorized", :get do
+        let(:header) { auth_header(create(:user)) }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sessions/user_spec.rb
+++ b/spec/requests/api/v1/sessions/user_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::Sessions::UserController, type: :request do
+  describe "GET #show" do
+    let(:path) { "/api/v1/sessions/#{cs.id}/user" }
+    let(:cs) { create(:client_session) }
+    let(:user) { cs.user }
+    let(:params) { {} }
+    let(:header) { auth_header(user) }
+
+    context "when session belongs to user" do
+      it_behaves_like "authorization", :get
+
+      it "returns the correct data" do
+        get path, headers: header
+        expect(response).to have_http_status(:success)
+        expect(json["links"]["self"]).to eq api_v1_client_session_user_url(cs)
+        expect(json["data"]["type"]).to eq "user"
+        expect(json["data"]["id"]).to eq user.id.to_s
+        expect(json["data"]["attributes"]["email"]).to eq user.email
+        expect(json["data"]["attributes"]["name"]).to eq user.name
+        expect(json["data"]["attributes"]["role"]).to eq "lead"
+      end
+    end
+
+    context "when session does not belong to user" do
+      it_behaves_like "unauthorized", :get do
+        let(:header) { auth_header(create(:user)) }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sessions/user_spec.rb
+++ b/spec/requests/api/v1/sessions/user_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe API::V1::Sessions::UserController, type: :request do
     let(:user) { cs.user }
     let(:params) { {} }
     let(:header) { auth_header(user) }
+    let(:os) { create(:occupation_standard) }
 
     context "when session belongs to user" do
+      before { user.favorites << os }
+
       it_behaves_like "authorization", :get
 
       it "returns the correct data" do
@@ -20,6 +23,12 @@ RSpec.describe API::V1::Sessions::UserController, type: :request do
         expect(json["data"]["attributes"]["email"]).to eq user.email
         expect(json["data"]["attributes"]["name"]).to eq user.name
         expect(json["data"]["attributes"]["role"]).to eq "lead"
+        expect(json["data"]["relationships"]["employer"]["data"]).to be nil
+        expect(json["data"]["relationships"]["favorites"]["data"].count).to eq 1
+        expect(json["data"]["relationships"]["favorites"]["data"][0]["type"]).to eq "occupation_standard"
+        expect(json["data"]["relationships"]["favorites"]["data"][0]["id"]).to eq os.id.to_s
+        expect(json["data"]["relationships"]["favorites"]["links"]["self"]).to eq relationships_favorites_api_v1_user_url(user)
+        expect(json["data"]["relationships"]["favorites"]["links"]["related"]).to eq api_v1_user_favorites_url(user)
       end
     end
 

--- a/spec/requests/api/v1/sessions_spec.rb
+++ b/spec/requests/api/v1/sessions_spec.rb
@@ -94,27 +94,34 @@ RSpec.describe API::V1::SessionsController, type: :request do
   end
 
   describe "GET #show" do
-    let(:path) { "/api/v1/sessions/abc123" }
     let(:user) { create(:user) }
-    let!(:client_session) { create(:client_session, id: "abc123", user: user) }
+    let!(:client_session) { create(:client_session, user: user) }
     let(:uuid) { client_session.id }
+    let(:path) { "/api/v1/sessions/#{uuid}" }
     let(:token) { JsonWebToken.encode(id: user.id, encrypted_password: user.encrypted_password, session_identifier: uuid) }
-
     let(:header) { { "HTTP_AUTHORIZATION" => "Bearer #{token}" } }
     let(:params) { {} }
 
-    it_behaves_like "authorization", :get
+    context "when viewed by owning user" do
+      it_behaves_like "authorization", :get
 
-    it "returns session data" do
-      get path, headers: header
-      expect(response).to have_http_status(:success)
-      expect(json["links"]["self"]).to eq api_v1_client_session_url(uuid)
-      expect(json["data"]["type"]).to eq "session"
-      expect(json["data"]["id"]).to eq uuid
-      expect(json["data"]["relationships"]["user"]["links"]["self"]).to eq relationships_user_api_v1_client_session_url(uuid)
-      expect(json["data"]["relationships"]["user"]["links"]["related"]).to eq api_v1_client_session_user_url(uuid)
-      expect(json["meta"]["access_token"]).to eq token
-      expect(json["meta"]["token_type"]).to eq "Bearer"
+      it "returns session data" do
+        get path, headers: header
+        expect(response).to have_http_status(:success)
+        expect(json["links"]["self"]).to eq api_v1_client_session_url(uuid)
+        expect(json["data"]["type"]).to eq "session"
+        expect(json["data"]["id"]).to eq uuid
+        expect(json["data"]["relationships"]["user"]["links"]["self"]).to eq relationships_user_api_v1_client_session_url(uuid)
+        expect(json["data"]["relationships"]["user"]["links"]["related"]).to eq api_v1_client_session_user_url(uuid)
+        expect(json["meta"]["access_token"]).to eq token
+        expect(json["meta"]["token_type"]).to eq "Bearer"
+      end
+    end
+
+    context "when viewed by non-owning user" do
+      it_behaves_like "unauthorized", :get do
+        let(:header) { auth_header(create(:user)) }
+      end
     end
   end
 

--- a/spec/requests/api/v1/sessions_spec.rb
+++ b/spec/requests/api/v1/sessions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe API::V1::SessionsController, type: :request do
     let(:path) { "/api/v1/sessions" }
 
     before do
-      allow(User).to receive(:new_token).and_return("abc123")
+      allow_any_instance_of(ClientSession).to receive(:id).and_return("abc123")
       allow(JsonWebToken).to receive(:encode).and_return("jwt456")
     end
 
@@ -27,13 +27,16 @@ RSpec.describe API::V1::SessionsController, type: :request do
         expect{
           post path, params: params
         }.to change(user.client_sessions, :count).by(1)
-        client_session = ClientSession.last
-        expect(client_session.identifier).to eq "abc123"
       end
 
-      it "returns access token" do
+      it "returns session data with access token" do
         post path, params: params
         expect(response).to have_http_status(:created)
+        expect(json["links"]["self"]).to eq api_v1_client_session_url("abc123")
+        expect(json["data"]["type"]).to eq "session"
+        expect(json["data"]["id"]).to eq "abc123"
+        expect(json["data"]["relationships"]["user"]["links"]["self"]).to eq relationships_user_api_v1_client_session_url("abc123")
+        expect(json["data"]["relationships"]["user"]["links"]["related"]).to eq api_v1_client_session_user_url("abc123")
         expect(json["meta"]["access_token"]).to eq "jwt456"
         expect(json["meta"]["token_type"]).to eq "Bearer"
       end
@@ -90,9 +93,34 @@ RSpec.describe API::V1::SessionsController, type: :request do
     end
   end
 
+  describe "GET #show" do
+    let(:path) { "/api/v1/sessions/abc123" }
+    let(:user) { create(:user) }
+    let!(:client_session) { create(:client_session, id: "abc123", user: user) }
+    let(:uuid) { client_session.id }
+    let(:token) { JsonWebToken.encode(id: user.id, encrypted_password: user.encrypted_password, session_identifier: uuid) }
+
+    let(:header) { { "HTTP_AUTHORIZATION" => "Bearer #{token}" } }
+    let(:params) { {} }
+
+    it_behaves_like "authorization", :get
+
+    it "returns session data" do
+      get path, headers: header
+      expect(response).to have_http_status(:success)
+      expect(json["links"]["self"]).to eq api_v1_client_session_url(uuid)
+      expect(json["data"]["type"]).to eq "session"
+      expect(json["data"]["id"]).to eq uuid
+      expect(json["data"]["relationships"]["user"]["links"]["self"]).to eq relationships_user_api_v1_client_session_url(uuid)
+      expect(json["data"]["relationships"]["user"]["links"]["related"]).to eq api_v1_client_session_user_url(uuid)
+      expect(json["meta"]["access_token"]).to eq token
+      expect(json["meta"]["token_type"]).to eq "Bearer"
+    end
+  end
+
   describe "DELETE #destroy" do
     let(:user) { create(:user) }
-    let(:path) { "/api/v1/sessions" }
+    let(:path) { "/api/v1/sessions/abc123" }
     let(:params) { {} }
     let!(:header) { auth_header(user) }
 

--- a/spec/requests/api/v1/users/favorites_spec.rb
+++ b/spec/requests/api/v1/users/favorites_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe API::V1::Users::FavoritesController, type: :request do
       end
     end
 
-    # Per {json:api} spec should probably return not found, but don't want to
-    # expose which users exist or not at this point.
     context "when requesting non-existent user" do
-      it_behaves_like "unauthorized", :get do
+      it_behaves_like "not found", :get do
         let(:path) { "/api/v1/users/999/favorites" }
       end
     end

--- a/spec/requests/api/v1/users/favorites_spec.rb
+++ b/spec/requests/api/v1/users/favorites_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::Users::FavoritesController, type: :request do
+  describe "GET #index" do
+    let(:path) { "/api/v1/users/#{user.id}/favorites" }
+    let(:user) { create(:user) }
+    let(:header) { auth_header(user) }
+    let(:params) { {} }
+
+    context "when user viewing own favorites" do
+      let(:os1) { create(:occupation_standard) }
+      let(:os2) { create(:occupation_standard) }
+
+      before { user.favorites << os1 << os2 }
+
+      it_behaves_like "authorization", :get
+
+      it "returns favorites by most recently added" do
+        get path, headers: header
+        expect(response).to have_http_status(:success)
+        expect(json["links"]["self"]).to eq api_v1_user_favorites_url(user)
+        expect(json["data"][0]["type"]).to eq "occupation_standard"
+        expect(json["data"][0]["id"]).to eq os2.id.to_s
+        expect(json["data"][0]["attributes"]["title"]).to eq os2.title
+        expect(json["data"][0]["attributes"]["organization_title"]).to eq os2.organization.title
+        expect(json["data"][0]["attributes"]["occupation_title"]).to eq os2.occupation.title
+        expect(json["data"][0]["attributes"]["industry_title"]).to be nil
+        expect(json["data"][0]["links"]["self"]).to eq api_v1_occupation_standard_url(os2)
+
+        expect(json["data"][1]["type"]).to eq "occupation_standard"
+        expect(json["data"][1]["id"]).to eq os1.id.to_s
+        expect(json["data"][1]["id"]).to eq os1.id.to_s
+        expect(json["data"][1]["type"]).to eq "occupation_standard"
+        expect(json["data"][1]["attributes"]["title"]).to eq os1.title
+        expect(json["data"][1]["attributes"]["organization_title"]).to eq os1.organization.title
+        expect(json["data"][1]["attributes"]["occupation_title"]).to eq os1.occupation.title
+        expect(json["data"][1]["attributes"]["industry_title"]).to be nil
+        expect(json["data"][1]["links"]["self"]).to eq api_v1_occupation_standard_url(os1)
+      end
+    end
+
+    context "when user viewing someone else's favorites" do
+      it_behaves_like "unauthorized", :get do
+        let(:header) { auth_header(create(:user)) }
+      end
+    end
+
+    # Per {json:api} spec should probably return not found, but don't want to
+    # expose which users exist or not at this point.
+    context "when requesting non-existent user" do
+      it_behaves_like "unauthorized", :get do
+        let(:path) { "/api/v1/users/999/favorites" }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users/relationships/favorites_spec.rb
+++ b/spec/requests/api/v1/users/relationships/favorites_spec.rb
@@ -47,10 +47,12 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
       let(:os) { create(:occupation_standard) }
       let(:params) {
         {
-          data: {
-            type: "occupation_standard",
-            id: os.id.to_s,
-          }
+          data: [
+            {
+              type: "occupation_standard",
+              id: os.id.to_s,
+            }
+          ]
         }
       }
       let(:user) { create(:user) }
@@ -102,10 +104,12 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
       let(:os) { create(:occupation_standard) }
       let(:params) {
         {
-          data: {
-            type: "occupation_standard",
-            id: os.id.to_s,
-          }
+          data: [
+            {
+              type: "occupation_standard",
+              id: os.id.to_s,
+            }
+          ]
         }
       }
       let(:user) { create(:user) }

--- a/spec/requests/api/v1/users/relationships/favorites_spec.rb
+++ b/spec/requests/api/v1/users/relationships/favorites_spec.rb
@@ -85,6 +85,27 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
 
           it_behaves_like "success", :post
         end
+
+        context "with bad occupation standard id" do
+          let(:params) {
+            {
+              data: [
+                {
+                  type: "occupation_standard",
+                  id: "999",
+                }
+              ]
+            }
+          }
+
+          it "does not create a new relationship record" do
+            expect{
+              post path, params: params, headers: header
+            }.to_not change(Relationship, :count)
+          end
+
+          it_behaves_like "success", :post
+        end
       end
 
       context "when adding favorite for someone else" do
@@ -141,6 +162,27 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
           end
 
           it_behaves_like "success", :delete
+        end
+
+        context "with bad occupation standard id" do
+          let(:params) {
+            {
+              data: [
+                {
+                  type: "occupation_standard",
+                  id: "999",
+                }
+              ]
+            }
+          }
+
+          it "does not create a new relationship record" do
+            expect{
+              delete path, params: params, headers: header
+            }.to_not change(Relationship, :count)
+          end
+
+          it_behaves_like "success", :post
         end
       end
 

--- a/spec/requests/api/v1/users/relationships/favorites_spec.rb
+++ b/spec/requests/api/v1/users/relationships/favorites_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe API::V1::FavoritesController, type: :request do
+RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :request do
   describe "POST #create" do
     let(:path) { "/api/v1/users/#{user.id}/relationships/favorites" }
 
@@ -111,3 +111,4 @@ RSpec.describe API::V1::FavoritesController, type: :request do
     end
   end
 end
+

--- a/spec/requests/api/v1/users/relationships/favorites_spec.rb
+++ b/spec/requests/api/v1/users/relationships/favorites_spec.rb
@@ -31,10 +31,8 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
       end
     end
 
-    # Per {json:api} spec should probably return not found, but don't want to
-    # expose which users exist or not at this point.
     context "when requesting non-existent user" do
-      it_behaves_like "unauthorized", :get do
+      it_behaves_like "not found", :get do
         let(:path) { "/api/v1/users/999/relationships/favorites" }
       end
     end
@@ -154,4 +152,3 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
     end
   end
 end
-

--- a/spec/requests/api/v1/users/relationships/favorites_spec.rb
+++ b/spec/requests/api/v1/users/relationships/favorites_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe API::V1::Users::Relationships::FavoritesController, type: :reques
         let(:header) { auth_header(create(:user)) }
       end
     end
+
+    # Per {json:api} spec should probably return not found, but don't want to
+    # expose which users exist or not at this point.
+    context "when requesting non-existent user" do
+      it_behaves_like "unauthorized", :get do
+        let(:path) { "/api/v1/users/999/relationships/favorites" }
+      end
+    end
   end
 
   describe "POST #create" do

--- a/spec/support/shared/status.rb
+++ b/spec/support/shared/status.rb
@@ -19,6 +19,13 @@ RSpec.shared_examples "unauthorized" do |method|
   end
 end
 
+RSpec.shared_examples "not found" do |method|
+  it "has not found status" do
+    send(method, path, params: params, headers: header)
+    expect(response).to have_http_status(:not_found)
+  end
+end
+
 RSpec.shared_examples "success" do |method|
   it "has success status" do
     send(method, path, params: params, headers: header)

--- a/spec/support/shared/status.rb
+++ b/spec/support/shared/status.rb
@@ -18,3 +18,10 @@ RSpec.shared_examples "unauthorized" do |method|
     expect(response).to have_http_status(:unauthorized)
   end
 end
+
+RSpec.shared_examples "success" do |method|
+  it "has success status" do
+    send(method, path, params: params, headers: header)
+    expect(response).to have_http_status(:success)
+  end
+end


### PR DESCRIPTION
closes #93 

## Description
- Fixes bug with duplicate work processes getting returned
- Added ability to create, delete, list occupation_standard favorites for a user
- Reworked sign in to more deliberately use session resource to fit with {json:api} spec.

## QA
In Postman:
- [ ] Sign in as foo@example.com/password user and retrieve Bearer token
- [ ] Create favorite [per spec](https://rapid-skills-favorites-wxsaqyz.herokuapp.com/api/v1/docs/#create-favorite)
- [ ] Delete favorite [per spec](https://rapid-skills-favorites-wxsaqyz.herokuapp.com/api/v1/docs/#delete-favorite)
- [ ] List favorites (relationships request only [per spec](https://rapid-skills-favorites-wxsaqyz.herokuapp.com/api/v1/docs/#list-favorites))
- [ ] List full favorites [per spec](https://rapid-skills-favorites-wxsaqyz.herokuapp.com/api/v1/docs/#list-favorites)
- [ ] Try to create/delete/list favorite for User 1. Should get unauthorized error.